### PR TITLE
added examples for cblas linker options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Go implementation of the BLAS API (incomplete, implements most of the float64 AP
 
 Binding to a C implementation of the cblas interface (e.g. ATLAS, OpenBLAS, intel MKL)
 
-On linux the linker flags (i.e. path to the BLAS library and library name) might have to be adapted.
+The linker flags (i.e. path to the BLAS library and library name) might have to be adapted.
+
+The recommended (free) option for good performance on both linux and darwin is OpenBLAS.
 
 ### blas/dbw
 
@@ -46,7 +48,7 @@ func init() {
 }
 
 func main() {
-	v := dbw.Vector{[]float64{1, 1, 1}, 3, 1}
+	v := dbw.NewVector([]float64{1, 1, 1})
 	fmt.Println("v has length:", dbw.Nrm2(v))
 }
 ```

--- a/cblas/blas.go
+++ b/cblas/blas.go
@@ -9,8 +9,11 @@ package cblas
 
 /*
 #cgo CFLAGS: -g -O2
-#cgo linux LDFLAGS: -L/home/dane/builds/OpenBLAS/ -lopenblas
+#cgo linux LDFLAGS: -lcblas
+//#cgo linux LDFLAGS: -lmkl_rt
+//#cgo linux LDFLAGS: -L/path/to/OpenBLAS -lopenblas
 #cgo darwin LDFLAGS: -DYA_BLAS -DYA_LAPACK -DYA_BLASMULT -framework vecLib
+//#cgo darwin LDFLAGS: -L/path/to/OpenBLAS -lopenblas
 #include "cblas.h"
 */
 import "C"


### PR DESCRIPTION
I realized that I pushed my own LDFLAGS some time ago.
I added examples for possible LDFLAGS and also added a line to the readme
recommending OpenBLAS which as far as I know is the most performant open
BLAS library.
Maybe we could add a script which clones and builds OpenBLAS and then generates cblas.go
with the correct LDFLAGS?
