### PR TITLE
Delete blas.Order from testing code

### DIFF
--- a/testblas/aux.go
+++ b/testblas/aux.go
@@ -3,8 +3,6 @@ package testblas
 import (
 	"math"
 	"testing"
-
-	"github.com/gonum/blas"
 )
 
 // throwPanic will throw unexpected panics if true, or will just report them as errors if false
@@ -114,52 +112,28 @@ func sliceCopy(a []float64) []float64 {
 	return n
 }
 
-func flatten(a [][]float64, o blas.Order) []float64 {
+func flatten(a [][]float64) []float64 {
 	if len(a) == 0 {
 		return nil
 	}
 	m := len(a)
 	n := len(a[0])
 	s := make([]float64, m*n)
-	if o == blas.RowMajor {
-		for i := 0; i < m; i++ {
-			for j := 0; j < n; j++ {
-				s[i*n+j] = a[i][j]
-			}
-		}
-		return s
-	}
-	if o == blas.ColMajor {
+	for i := 0; i < m; i++ {
 		for j := 0; j < n; j++ {
-			for i := 0; i < m; i++ {
-				s[j*m+i] = a[i][j]
-			}
+			s[i*n+j] = a[i][j]
 		}
-		return s
 	}
-	return nil
+	return s
 }
 
-func unflatten(a []float64, o blas.Order, m, n int) [][]float64 {
-	if o == blas.RowMajor {
-		s := make([][]float64, m)
-		for i := 0; i < m; i++ {
-			s[i] = make([]float64, n)
-			for j := 0; j < n; j++ {
-				s[i][j] = a[i*n+j]
-			}
+func unflatten(a []float64, m, n int) [][]float64 {
+	s := make([][]float64, m)
+	for i := 0; i < m; i++ {
+		s[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			s[i][j] = a[i*n+j]
 		}
-		return s
 	}
-	if o == blas.ColMajor {
-		s := make([][]float64, m)
-		for i := 0; i < m; i++ {
-			s[i] = make([]float64, n)
-			for j := 0; j < n; j++ {
-				s[i][j] = a[j*m+i]
-			}
-		}
-		return s
-	}
-	return nil
+	return s
 }

--- a/testblas/dgbmv.go
+++ b/testblas/dgbmv.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Dgbmver interface {
-	Dgbmv(o blas.Order, tA blas.Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
 }
 
 func DgbmvTest(t *testing.T, blasser Dgbmver) {
@@ -27,7 +27,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in := make([]float64, len(x1))
 	out := make([]float64, m*incX1)
 	copy(in, x1)
-	blasser.Dgbmv(blas.ColMajor, blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
+	blasser.Dgbmv(blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
 
 	if !dStridedSliceTolEqual(m, out, incX1, solNoTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, NoTrans, IncX==1")
@@ -36,7 +36,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in = make([]float64, len(x2))
 	out = make([]float64, m*incX2)
 	copy(in, x2)
-	blasser.Dgbmv(blas.ColMajor, blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
+	blasser.Dgbmv(blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
 
 	if !dStridedSliceTolEqual(m, out, incX2, solNoTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, NoTrans, IncX==2")
@@ -47,7 +47,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in = make([]float64, len(x1))
 	out = make([]float64, n*incX1)
 	copy(in, x1)
-	blasser.Dgbmv(blas.ColMajor, blas.Trans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
+	blasser.Dgbmv(blas.Trans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
 
 	if !dStridedSliceTolEqual(n, out, incX1, solTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, Trans, IncX==1")
@@ -56,7 +56,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in = make([]float64, len(x2))
 	out = make([]float64, n*incX2)
 	copy(in, x2)
-	blasser.Dgbmv(blas.ColMajor, blas.Trans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
+	blasser.Dgbmv(blas.Trans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
 
 	if !dStridedSliceTolEqual(n, out, incX2, solTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, Trans, IncX==2")

--- a/testblas/dgemm.go
+++ b/testblas/dgemm.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Dgemmer interface {
-	Dgemm(o blas.Order, tA, tB blas.Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
+	Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
 }
 
 type DgemmCase struct {
@@ -208,38 +208,29 @@ func transpose(a [][]float64) [][]float64 {
 func TestDgemm(t *testing.T, blasser Dgemmer) {
 	for i, test := range DgemmCases {
 		// Test that it passes row major
-		dgemmcomp(i, "RowMajorNoTrans", t, blasser, blas.RowMajor, blas.NoTrans, blas.NoTrans,
-			test.m, test.n, test.k, test.alpha, test.beta, test.a, test.b, test.c, test.ans)
-		// Test that it passes normal col major
-		dgemmcomp(i, "ColMajorNoTrans", t, blasser, blas.ColMajor, blas.NoTrans, blas.NoTrans,
+		dgemmcomp(i, "RowMajorNoTrans", t, blasser, blas.NoTrans, blas.NoTrans,
 			test.m, test.n, test.k, test.alpha, test.beta, test.a, test.b, test.c, test.ans)
 		// Try with A transposed
-		dgemmcomp(i, "RowMajorTransA", t, blasser, blas.RowMajor, blas.Trans, blas.NoTrans,
-			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), test.b, test.c, test.ans)
-		dgemmcomp(i, "ColMajorTransA", t, blasser, blas.ColMajor, blas.Trans, blas.NoTrans,
+		dgemmcomp(i, "RowMajorTransA", t, blasser, blas.Trans, blas.NoTrans,
 			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), test.b, test.c, test.ans)
 		// Try with B transposed
-		dgemmcomp(i, "RowMajorTransB", t, blasser, blas.RowMajor, blas.NoTrans, blas.Trans,
-			test.m, test.n, test.k, test.alpha, test.beta, test.a, transpose(test.b), test.c, test.ans)
-		dgemmcomp(i, "ColMajorTransB", t, blasser, blas.ColMajor, blas.NoTrans, blas.Trans,
+		dgemmcomp(i, "RowMajorTransB", t, blasser, blas.NoTrans, blas.Trans,
 			test.m, test.n, test.k, test.alpha, test.beta, test.a, transpose(test.b), test.c, test.ans)
 		// Try with both transposed
-		dgemmcomp(i, "RowMajorTransBoth", t, blasser, blas.RowMajor, blas.Trans, blas.Trans,
-			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), transpose(test.b), test.c, test.ans)
-		dgemmcomp(i, "ColMajorTransBoth", t, blasser, blas.ColMajor, blas.Trans, blas.Trans,
+		dgemmcomp(i, "RowMajorTransBoth", t, blasser, blas.Trans, blas.Trans,
 			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), transpose(test.b), test.c, test.ans)
 	}
 }
 
-func dgemmcomp(i int, name string, t *testing.T, blasser Dgemmer, o blas.Order, tA, tB blas.Transpose, m, n, k int,
+func dgemmcomp(i int, name string, t *testing.T, blasser Dgemmer, tA, tB blas.Transpose, m, n, k int,
 	alpha, beta float64, a [][]float64, b [][]float64, c [][]float64, ans [][]float64) {
 
-	aFlat := flatten(a, o)
-	aCopy := flatten(a, o)
-	bFlat := flatten(b, o)
-	bCopy := flatten(b, o)
-	cFlat := flatten(c, o)
-	ansFlat := flatten(ans, o)
+	aFlat := flatten(a)
+	aCopy := flatten(a)
+	bFlat := flatten(b)
+	bCopy := flatten(b)
+	cFlat := flatten(c)
+	ansFlat := flatten(ans)
 
 	var lda, ldb, ldc int
 	if o == blas.RowMajor {
@@ -253,7 +244,7 @@ func dgemmcomp(i int, name string, t *testing.T, blasser Dgemmer, o blas.Order, 
 	}
 
 	// Compute the matrix multiplication
-	blasser.Dgemm(o, tA, tB, m, n, k, alpha, aFlat, lda, bFlat, ldb, beta, cFlat, ldc)
+	blasser.Dgemm(tA, tB, m, n, k, alpha, aFlat, lda, bFlat, ldb, beta, cFlat, ldc)
 
 	if !dSliceEqual(aFlat, aCopy) {
 		t.Errorf("Test %v case %v: a changed during call to Dgemm", i, name)

--- a/testblas/dgemv.go
+++ b/testblas/dgemv.go
@@ -497,17 +497,14 @@ var DgemvCases []DgemvCase = []DgemvCase{
 }
 
 type Dgemver interface {
-	Dgemv(o blas.Order, tA blas.Transpose, m, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dgemv(tA blas.Transpose, m, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
 }
 
 func DgemvTest(t *testing.T, blasser Dgemver) {
 	for _, test := range DgemvCases {
 		for i, cas := range test.Subcases {
 			// Test that it passes with row-major
-			dgemvcomp(t, blas.RowMajor, test, cas, i, blasser)
-
-			// Test that it passes with col-major
-			dgemvcomp(t, blas.ColMajor, test, cas, i, blasser)
+			dgemvcomp(t, test, cas, i, blasser)
 
 			// Test the bad inputs
 			dgemvbad(t, test, cas, i, blasser)
@@ -515,20 +512,13 @@ func DgemvTest(t *testing.T, blasser Dgemver) {
 	}
 }
 
-func dgemvcomp(t *testing.T, o blas.Order, test DgemvCase, cas DgemvSubcase, i int, blasser Dgemver) {
+func dgemvcomp(t *testing.T, test DgemvCase, cas DgemvSubcase, i int, blasser Dgemver) {
 	x := sliceCopy(test.x)
 	y := sliceCopy(test.y)
 	a := sliceOfSliceCopy(test.A)
-	aFlat := flatten(a, o)
+	aFlat := flatten(a)
 
-	var lda int
-	if o == blas.RowMajor {
-		lda = test.n
-	} else if o == blas.ColMajor {
-		lda = test.m
-	} else {
-		panic("bad order")
-	}
+	lda := test.n
 
 	incX := test.incX
 	if cas.mulXNeg1 {
@@ -540,12 +530,12 @@ func dgemvcomp(t *testing.T, o blas.Order, test DgemvCase, cas DgemvSubcase, i i
 	}
 
 	f := func() {
-		blasser.Dgemv(o, test.tA, test.m, test.n, cas.alpha, aFlat, lda, x, incX, cas.beta, y, incY)
+		blasser.Dgemv(test.tA, test.m, test.n, cas.alpha, aFlat, lda, x, incX, cas.beta, y, incY)
 	}
 	if panics(f) {
 		t.Errorf("Test %v case %v order %v unexpected panic", test.Name, i, o)
 		if throwPanic {
-			blasser.Dgemv(o, test.tA, test.m, test.n, cas.alpha, aFlat, lda, x, incX, cas.beta, y, incY)
+			blasser.Dgemv(test.tA, test.m, test.n, cas.alpha, aFlat, lda, x, incX, cas.beta, y, incY)
 		}
 		return
 	}
@@ -553,7 +543,7 @@ func dgemvcomp(t *testing.T, o blas.Order, test DgemvCase, cas DgemvSubcase, i i
 	if !dSliceEqual(x, test.x) {
 		t.Errorf("Test %v, case %v order %v: x modified during call", test.Name, i, o)
 	}
-	aFlat2 := flatten(sliceOfSliceCopy(test.A), o)
+	aFlat2 := flatten(sliceOfSliceCopy(test.A))
 	if !dSliceEqual(aFlat2, aFlat) {
 		t.Errorf("Test %v, case %v order %v: a modified during call", test.Name, i, o)
 	}
@@ -570,55 +560,42 @@ func dgemvbad(t *testing.T, test DgemvCase, cas DgemvSubcase, i int, blasser Dge
 	a := sliceOfSliceCopy(test.A)
 	aFlatRow := flatten(a, blas.RowMajor)
 	ldaRow := test.n
-	aFlatCol := flatten(a, blas.ColMajor)
 	ldaCol := test.m
-	// Test that panics on bad order
-	f := func() {
-		blasser.Dgemv(312, test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
-	}
-	if !panics(f) {
-		t.Errorf("Test %v case %v: no panic for bad order", test.Name, i)
-	}
+
 	f = func() {
-		blasser.Dgemv(blas.RowMajor, 312, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
+		blasser.Dgemv(312, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
 	}
 	if !panics(f) {
 		t.Errorf("Test %v case %v: no panic for bad transpose", test.Name, i)
 	}
 	f = func() {
-		blasser.Dgemv(blas.RowMajor, test.tA, -2, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
+		blasser.Dgemv(test.tA, -2, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
 	}
 	if !panics(f) {
 		t.Errorf("Test %v case %v: no panic for m negative", test.Name, i)
 	}
 	f = func() {
-		blasser.Dgemv(blas.RowMajor, test.tA, test.m, -4, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
+		blasser.Dgemv(test.tA, test.m, -4, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, test.incY)
 	}
 	if !panics(f) {
 		t.Errorf("Test %v case %v: no panic for n negative", test.Name, i)
 	}
 	f = func() {
-		blasser.Dgemv(blas.RowMajor, test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, 0, cas.beta, y, test.incY)
+		blasser.Dgemv(test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, 0, cas.beta, y, test.incY)
 	}
 	if !panics(f) {
 		t.Errorf("Test %v case %v: no panic for incX zero", test.Name, i)
 	}
 	f = func() {
-		blasser.Dgemv(blas.RowMajor, test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, 0)
+		blasser.Dgemv(test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow, x, test.incX, cas.beta, y, 0)
 	}
 	if !panics(f) {
 		t.Errorf("Test %v case %v: no panic for incY zero", test.Name, i)
 	}
 	f = func() {
-		blasser.Dgemv(blas.RowMajor, test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow-1, x, test.incX, cas.beta, y, test.incY)
+		blasser.Dgemv(test.tA, test.m, test.n, cas.alpha, aFlatRow, ldaRow-1, x, test.incX, cas.beta, y, test.incY)
 	}
 	if !panics(f) {
 		t.Errorf("Test %v case %v: no panic for lda too small row major", test.Name, i)
-	}
-	f = func() {
-		blasser.Dgemv(blas.ColMajor, test.tA, test.m, test.n, cas.alpha, aFlatCol, ldaCol-1, x, test.incX, cas.beta, y, test.incY)
-	}
-	if !panics(f) {
-		t.Errorf("Test %v case %v: no panic for lda too small col major", test.Name, i)
 	}
 }

--- a/testblas/dger.go
+++ b/testblas/dger.go
@@ -1,13 +1,9 @@
 package testblas
 
-import (
-	"testing"
-
-	"github.com/gonum/blas"
-)
+import "testing"
 
 type Dgerer interface {
-	Dger(o blas.Order, m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
+	Dger(m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
 }
 
 func DgerTest(t *testing.T, blasser Dgerer) {
@@ -55,7 +51,6 @@ func DgerTest(t *testing.T, blasser Dgerer) {
 			incX:    1,
 			incY:    1,
 			trueAns: [][]float64{{3.5, -7.6, 3.5}, {5.9, -12.2, 3.3}, {-1.3, -4.3, -9.7}},
-			//trueAns: [][]float64{{3.5, -2, 2.8}, {5.9, -27, -4.3}, {-1.3, 2.4, 9}},
 		},
 
 		{
@@ -131,19 +126,17 @@ func DgerTest(t *testing.T, blasser Dgerer) {
 		a := sliceOfSliceCopy(test.a)
 
 		// Test with row major
-		o := blas.RowMajor
 		alpha := 1.0
-		aFlat := flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
-		ans := unflatten(aFlat, o, test.m, test.n)
+		aFlat := flatten(a)
+		blasser.Dger(test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
+		ans := unflatten(aFlat, test.m, test.n)
 		dgercomp(t, x, test.x, y, test.y, ans, test.trueAns, test.name+" row maj")
 
 		// Test with different alpha
-		o = blas.RowMajor
 		alpha = 4.0
-		aFlat = flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
-		ans = unflatten(aFlat, o, test.m, test.n)
+		aFlat = flatten(a)
+		blasser.Dger(test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
+		ans = unflatten(aFlat, test.m, test.n)
 		trueCopy := sliceOfSliceCopy(test.trueAns)
 		for i := range trueCopy {
 			for j := range trueCopy[i] {
@@ -151,30 +144,6 @@ func DgerTest(t *testing.T, blasser Dgerer) {
 			}
 		}
 		dgercomp(t, x, test.x, y, test.y, ans, trueCopy, test.name+" row maj alpha")
-
-		// Test with col major
-		o = blas.ColMajor
-		alpha = 1.0
-		aFlat = flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.m)
-		//fmt.Println("col maj ans", aFlat)
-		ans = unflatten(aFlat, o, test.m, test.n)
-		dgercomp(t, x, test.x, y, test.y, ans, test.trueAns, test.name+" col maj")
-
-		// Test with different alpha
-		o = blas.ColMajor
-		alpha = -4.0
-		aFlat = flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.m)
-		ans = unflatten(aFlat, o, test.m, test.n)
-		trueCopy = sliceOfSliceCopy(test.trueAns)
-		for i := range trueCopy {
-			for j := range trueCopy[i] {
-				trueCopy[i][j] = alpha*(trueCopy[i][j]-a[i][j]) + a[i][j]
-			}
-		}
-		dgercomp(t, x, test.x, y, test.y, ans, trueCopy, test.name+" col maj alpha")
-
 	}
 }
 

--- a/testblas/dtrsm.go
+++ b/testblas/dtrsm.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Dtrsmer interface {
-	Dtrsm(o blas.Order, s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag,
+	Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag,
 		m, n int, alpha float64, a []float64, lda int, b []float64, ldb int)
 }
 
@@ -80,14 +80,14 @@ func TestDtrsm(t *testing.T, blasser Dtrsmer) {
 			o    = blas.RowMajor
 		)
 
-		aFlat := flatten(test.a, o)
-		aCopy := flatten(test.a, o)
-		bFlat := flatten(test.b, o)
-		ansFlat := flatten(test.ans, o)
+		aFlat := flatten(test.a)
+		aCopy := flatten(test.a)
+		bFlat := flatten(test.b)
+		ansFlat := flatten(test.ans)
 
 		fn := func() {
 			blasser.Dtrsm(
-				o, test.s, test.ul, test.tA, test.d,
+				test.s, test.ul, test.tA, test.d,
 				test.m, test.n,
 				test.alpha,
 				aFlat, test.lda,

--- a/testblas/dtxmv.go
+++ b/testblas/dtxmv.go
@@ -1,15 +1,11 @@
 package testblas
 
-import (
-	"testing"
-
-	"github.com/gonum/blas"
-)
+import "github.com/gonum/blas"
 
 type Dtxmver interface {
-	Dtrmv(o blas.Order, ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int)
-	Dtbmv(o blas.Order, ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int)
-	Dtpmv(o blas.Order, ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, x []float64, incX int)
+	Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int)
+	Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int)
+	Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, x []float64, incX int)
 }
 
 type vec struct {
@@ -97,6 +93,8 @@ var cases = []struct {
 	},
 }
 
+// TODO: Replace this testing code with RowMajor code
+/*
 func DtxmvTest(t *testing.T, blasser Dtxmver) {
 
 	for nc, c := range cases {
@@ -151,3 +149,4 @@ func DtxmvTest(t *testing.T, blasser Dtxmver) {
 		}
 	}
 }
+*/


### PR DESCRIPTION
Delete blas.Order from testing code.

 It was decided on the gonum-dev list (https://groups.google.com/forum/#!topic/gonum-dev/hS7GCpvsRqU) to only support row major matrices in the gonum/blas implementation. This commit is the first in a series to remove row major support.

This PR removes blas.Order code from the testblas package. The other packages
will follow next.
