### PR TITLE
Remove blas support for column major matrices

### DIFF
--- a/blas.go
+++ b/blas.go
@@ -11,6 +11,9 @@ by the BLAS standard.
 
 Quick Reference Guide to the BLAS from http://www.netlib.org/lapack/lug/node145.html
 
+This version is modified to remove the "order" option. All matrix operations are
+on row-order matrices.
+
 Level 1 BLAS
 
 	        dim scalar vector   vector   scalars              5-element prefixes
@@ -36,48 +39,48 @@ Level 2 BLAS
 
 	        options                   dim   b-width scalar matrix  vector   scalar vector   prefixes
 
-	_gemv ( order,        trans,      m, n,         alpha, a, lda, x, incX, beta,  y, incY ) S, D, C, Z
-	_gbmv ( order,        trans,      m, n, kL, kU, alpha, a, lda, x, incX, beta,  y, incY ) S, D, C, Z
-	_hemv ( order, uplo,                 n,         alpha, a, lda, x, incX, beta,  y, incY ) C, Z
-	_hbmv ( order, uplo,                 n, k,      alpha, a, lda, x, incX, beta,  y, incY ) C, Z
-	_hpmv ( order, uplo,                 n,         alpha, ap,     x, incX, beta,  y, incY ) C, Z
-	_symv ( order, uplo,                 n,         alpha, a, lda, x, incX, beta,  y, incY ) S, D
-	_sbmv ( order, uplo,                 n, k,      alpha, a, lda, x, incX, beta,  y, incY ) S, D
-	_spmv ( order, uplo,                 n,         alpha, ap,     x, incX, beta,  y, incY ) S, D
-	_trmv ( order, uplo, trans, diag,    n,                a, lda, x, incX )                 S, D, C, Z
-	_tbmv ( order, uplo, trans, diag,    n, k,             a, lda, x, incX )                 S, D, C, Z
-	_tpmv ( order, uplo, trans, diag,    n,                ap,     x, incX )                 S, D, C, Z
-	_trsv ( order, uplo, trans, diag,    n,                a, lda, x, incX )                 S, D, C, Z
-	_tbsv ( order, uplo, trans, diag,    n, k,             a, lda, x, incX )                 S, D, C, Z
-	_tpsv ( order, uplo, trans, diag,    n,                ap,     x, incX )                 S, D, C, Z
+	_gemv (        trans,      m, n,         alpha, a, lda, x, incX, beta,  y, incY ) S, D, C, Z
+	_gbmv (        trans,      m, n, kL, kU, alpha, a, lda, x, incX, beta,  y, incY ) S, D, C, Z
+	_hemv ( uplo,                 n,         alpha, a, lda, x, incX, beta,  y, incY ) C, Z
+	_hbmv ( uplo,                 n, k,      alpha, a, lda, x, incX, beta,  y, incY ) C, Z
+	_hpmv ( uplo,                 n,         alpha, ap,     x, incX, beta,  y, incY ) C, Z
+	_symv ( uplo,                 n,         alpha, a, lda, x, incX, beta,  y, incY ) S, D
+	_sbmv ( uplo,                 n, k,      alpha, a, lda, x, incX, beta,  y, incY ) S, D
+	_spmv ( uplo,                 n,         alpha, ap,     x, incX, beta,  y, incY ) S, D
+	_trmv ( uplo, trans, diag,    n,                a, lda, x, incX )                 S, D, C, Z
+	_tbmv ( uplo, trans, diag,    n, k,             a, lda, x, incX )                 S, D, C, Z
+	_tpmv ( uplo, trans, diag,    n,                ap,     x, incX )                 S, D, C, Z
+	_trsv ( uplo, trans, diag,    n,                a, lda, x, incX )                 S, D, C, Z
+	_tbsv ( uplo, trans, diag,    n, k,             a, lda, x, incX )                 S, D, C, Z
+	_tpsv ( uplo, trans, diag,    n,                ap,     x, incX )                 S, D, C, Z
 
 	        options                   dim   scalar vector   vector   matrix  prefixes
 
-	_ger  ( order,                    m, n, alpha, x, incX, y, incY, a, lda ) S, D
-	_geru ( order,                    m, n, alpha, x, incX, y, incY, a, lda ) C, Z
-	_gerc ( order,                    m, n, alpha, x, incX, y, incY, a, lda ) C, Z
-	_her  ( order, uplo,                 n, alpha, x, incX,          a, lda ) C, Z
-	_hpr  ( order, uplo,                 n, alpha, x, incX,          ap )     C, Z
-	_her2 ( order, uplo,                 n, alpha, x, incX, y, incY, a, lda ) C, Z
-	_hpr2 ( order, uplo,                 n, alpha, x, incX, y, incY, ap )     C, Z
-	_syr  ( order, uplo,                 n, alpha, x, incX,          a, lda ) S, D
-	_spr  ( order, uplo,                 n, alpha, x, incX,          ap )     S, D
-	_syr2 ( order, uplo,                 n, alpha, x, incX, y, incY, a, lda ) S, D
-	_spr2 ( order, uplo,                 n, alpha, x, incX, y, incY, ap )     S, D
+	_ger  (                    m, n, alpha, x, incX, y, incY, a, lda ) S, D
+	_geru (                    m, n, alpha, x, incX, y, incY, a, lda ) C, Z
+	_gerc (                    m, n, alpha, x, incX, y, incY, a, lda ) C, Z
+	_her  ( uplo,                 n, alpha, x, incX,          a, lda ) C, Z
+	_hpr  ( uplo,                 n, alpha, x, incX,          ap )     C, Z
+	_her2 ( uplo,                 n, alpha, x, incX, y, incY, a, lda ) C, Z
+	_hpr2 ( uplo,                 n, alpha, x, incX, y, incY, ap )     C, Z
+	_syr  ( uplo,                 n, alpha, x, incX,          a, lda ) S, D
+	_spr  ( uplo,                 n, alpha, x, incX,          ap )     S, D
+	_syr2 ( uplo,                 n, alpha, x, incX, y, incY, a, lda ) S, D
+	_spr2 ( uplo,                 n, alpha, x, incX, y, incY, ap )     S, D
 
 Level 3 BLAS
 
 	        options                                 dim      scalar matrix  matrix  scalar matrix  prefixes
 
-	_gemm ( order,             transA, transB,      m, n, k, alpha, a, lda, b, ldb, beta,  c, ldc ) S, D, C, Z
-	_symm ( order, side, uplo,                      m, n,    alpha, a, lda, b, ldb, beta,  c, ldc ) S, D, C, Z
-	_hemm ( order, side, uplo,                      m, n,    alpha, a, lda, b, ldb, beta,  c, ldc ) C, Z
-	_syrk ( order,       uplo, trans,                  n, k, alpha, a, lda,         beta,  c, ldc ) S, D, C, Z
-	_herk ( order,       uplo, trans,                  n, k, alpha, a, lda,         beta,  c, ldc ) C, Z
-	_syr2k( order,       uplo, trans,                  n, k, alpha, a, lda, b, ldb, beta,  c, ldc ) S, D, C, Z
-	_her2k( order,       uplo, trans,                  n, k, alpha, a, lda, b, ldb, beta,  c, ldc ) C, Z
-	_trmm ( order, side, uplo, transA,        diag, m, n,    alpha, a, lda, b, ldb )                S, D, C, Z
-	_trsm ( order, side, uplo, transA,        diag, m, n,    alpha, a, lda, b, ldb )                S, D, C, Z
+	_gemm (             transA, transB,      m, n, k, alpha, a, lda, b, ldb, beta,  c, ldc ) S, D, C, Z
+	_symm ( side, uplo,                      m, n,    alpha, a, lda, b, ldb, beta,  c, ldc ) S, D, C, Z
+	_hemm ( side, uplo,                      m, n,    alpha, a, lda, b, ldb, beta,  c, ldc ) C, Z
+	_syrk (       uplo, trans,                  n, k, alpha, a, lda,         beta,  c, ldc ) S, D, C, Z
+	_herk (       uplo, trans,                  n, k, alpha, a, lda,         beta,  c, ldc ) C, Z
+	_syr2k(       uplo, trans,                  n, k, alpha, a, lda, b, ldb, beta,  c, ldc ) S, D, C, Z
+	_her2k(       uplo, trans,                  n, k, alpha, a, lda, b, ldb, beta,  c, ldc ) C, Z
+	_trmm ( side, uplo, transA,        diag, m, n,    alpha, a, lda, b, ldb )                S, D, C, Z
+	_trsm ( side, uplo, transA,        diag, m, n,    alpha, a, lda, b, ldb )                S, D, C, Z
 
 Meaning of prefixes
 
@@ -127,16 +130,6 @@ type DrotmParams struct {
 	Flag
 	H [4]float64 // Column-major 2 by 2 matrix.
 }
-
-// Type Order is used to specify the matrix storage format. An implementation
-// may not implement both orders and must panic if a routine is called using
-// an unimplemented order.
-type Order int
-
-const (
-	RowMajor Order = 101 + iota
-	ColMajor
-)
 
 // Type Transpose is used to specify the transposition operation for a
 // routine.
@@ -203,32 +196,32 @@ type Float32Level1 interface {
 
 // Float32Level2 implements the single precision real BLAS Level 2 routines.
 type Float32Level2 interface {
-	Sgemv(o Order, tA Transpose, m, n int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
-	Sgbmv(o Order, tA Transpose, m, n, kL, kU int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
-	Strmv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []float32, lda int, x []float32, incX int)
-	Stbmv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []float32, lda int, x []float32, incX int)
-	Stpmv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []float32, x []float32, incX int)
-	Strsv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []float32, lda int, x []float32, incX int)
-	Stbsv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []float32, lda int, x []float32, incX int)
-	Stpsv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []float32, x []float32, incX int)
-	Ssymv(o Order, ul Uplo, n int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
-	Ssbmv(o Order, ul Uplo, n, k int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
-	Sspmv(o Order, ul Uplo, n int, alpha float32, ap []float32, x []float32, incX int, beta float32, y []float32, incY int)
-	Sger(o Order, m, n int, alpha float32, x []float32, incX int, y []float32, incY int, a []float32, lda int)
-	Ssyr(o Order, ul Uplo, n int, alpha float32, x []float32, incX int, a []float32, lda int)
-	Sspr(o Order, ul Uplo, n int, alpha float32, x []float32, incX int, ap []float32)
-	Ssyr2(o Order, ul Uplo, n int, alpha float32, x []float32, incX int, y []float32, incY int, a []float32, lda int)
-	Sspr2(o Order, ul Uplo, n int, alpha float32, x []float32, incX int, y []float32, incY int, a []float32)
+	Sgemv(tA Transpose, m, n int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
+	Sgbmv(tA Transpose, m, n, kL, kU int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
+	Strmv(ul Uplo, tA Transpose, d Diag, n int, a []float32, lda int, x []float32, incX int)
+	Stbmv(ul Uplo, tA Transpose, d Diag, n, k int, a []float32, lda int, x []float32, incX int)
+	Stpmv(ul Uplo, tA Transpose, d Diag, n int, ap []float32, x []float32, incX int)
+	Strsv(ul Uplo, tA Transpose, d Diag, n int, a []float32, lda int, x []float32, incX int)
+	Stbsv(ul Uplo, tA Transpose, d Diag, n, k int, a []float32, lda int, x []float32, incX int)
+	Stpsv(ul Uplo, tA Transpose, d Diag, n int, ap []float32, x []float32, incX int)
+	Ssymv(ul Uplo, n int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
+	Ssbmv(ul Uplo, n, k int, alpha float32, a []float32, lda int, x []float32, incX int, beta float32, y []float32, incY int)
+	Sspmv(ul Uplo, n int, alpha float32, ap []float32, x []float32, incX int, beta float32, y []float32, incY int)
+	Sger(m, n int, alpha float32, x []float32, incX int, y []float32, incY int, a []float32, lda int)
+	Ssyr(ul Uplo, n int, alpha float32, x []float32, incX int, a []float32, lda int)
+	Sspr(ul Uplo, n int, alpha float32, x []float32, incX int, ap []float32)
+	Ssyr2(ul Uplo, n int, alpha float32, x []float32, incX int, y []float32, incY int, a []float32, lda int)
+	Sspr2(ul Uplo, n int, alpha float32, x []float32, incX int, y []float32, incY int, a []float32)
 }
 
 // Float32Level3 implements the single precision real BLAS Level 3 routines.
 type Float32Level3 interface {
-	Sgemm(o Order, tA, tB Transpose, m, n, k int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int)
-	Ssymm(o Order, s Side, ul Uplo, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int)
-	Ssyrk(o Order, ul Uplo, t Transpose, n, k int, alpha float32, a []float32, lda int, beta float32, c []float32, ldc int)
-	Ssyr2k(o Order, ul Uplo, t Transpose, n, k int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int)
-	Strmm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int)
-	Strsm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int)
+	Sgemm(tA, tB Transpose, m, n, k int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int)
+	Ssymm(s Side, ul Uplo, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int)
+	Ssyrk(ul Uplo, t Transpose, n, k int, alpha float32, a []float32, lda int, beta float32, c []float32, ldc int)
+	Ssyr2k(ul Uplo, t Transpose, n, k int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int)
+	Strmm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int)
+	Strsm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int)
 }
 
 // Float64 implements the single precision real BLAS routines.
@@ -256,32 +249,32 @@ type Float64Level1 interface {
 
 // Float64Level2 implements the double precision real BLAS Level 2 routines.
 type Float64Level2 interface {
-	Dgemv(o Order, tA Transpose, m, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
-	Dgbmv(o Order, tA Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
-	Dtrmv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []float64, lda int, x []float64, incX int)
-	Dtbmv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []float64, lda int, x []float64, incX int)
-	Dtpmv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []float64, x []float64, incX int)
-	Dtrsv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []float64, lda int, x []float64, incX int)
-	Dtbsv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []float64, lda int, x []float64, incX int)
-	Dtpsv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []float64, x []float64, incX int)
-	Dsymv(o Order, ul Uplo, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
-	Dsbmv(o Order, ul Uplo, n, k int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
-	Dspmv(o Order, ul Uplo, n int, alpha float64, ap []float64, x []float64, incX int, beta float64, y []float64, incY int)
-	Dger(o Order, m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
-	Dsyr(o Order, ul Uplo, n int, alpha float64, x []float64, incX int, a []float64, lda int)
-	Dspr(o Order, ul Uplo, n int, alpha float64, x []float64, incX int, ap []float64)
-	Dsyr2(o Order, ul Uplo, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
-	Dspr2(o Order, ul Uplo, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64)
+	Dgemv(tA Transpose, m, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dgbmv(tA Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dtrmv(ul Uplo, tA Transpose, d Diag, n int, a []float64, lda int, x []float64, incX int)
+	Dtbmv(ul Uplo, tA Transpose, d Diag, n, k int, a []float64, lda int, x []float64, incX int)
+	Dtpmv(ul Uplo, tA Transpose, d Diag, n int, ap []float64, x []float64, incX int)
+	Dtrsv(ul Uplo, tA Transpose, d Diag, n int, a []float64, lda int, x []float64, incX int)
+	Dtbsv(ul Uplo, tA Transpose, d Diag, n, k int, a []float64, lda int, x []float64, incX int)
+	Dtpsv(ul Uplo, tA Transpose, d Diag, n int, ap []float64, x []float64, incX int)
+	Dsymv(ul Uplo, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dsbmv(ul Uplo, n, k int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dspmv(ul Uplo, n int, alpha float64, ap []float64, x []float64, incX int, beta float64, y []float64, incY int)
+	Dger(m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
+	Dsyr(ul Uplo, n int, alpha float64, x []float64, incX int, a []float64, lda int)
+	Dspr(ul Uplo, n int, alpha float64, x []float64, incX int, ap []float64)
+	Dsyr2(ul Uplo, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
+	Dspr2(ul Uplo, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64)
 }
 
 // Float64Level3 implements the double precision real BLAS Level 3 routines.
 type Float64Level3 interface {
-	Dgemm(o Order, tA, tB Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
-	Dsymm(o Order, s Side, ul Uplo, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
-	Dsyrk(o Order, ul Uplo, t Transpose, n, k int, alpha float64, a []float64, lda int, beta float64, c []float64, ldc int)
-	Dsyr2k(o Order, ul Uplo, t Transpose, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
-	Dtrmm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int)
-	Dtrsm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int)
+	Dgemm(tA, tB Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
+	Dsymm(s Side, ul Uplo, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
+	Dsyrk(ul Uplo, t Transpose, n, k int, alpha float64, a []float64, lda int, beta float64, c []float64, ldc int)
+	Dsyr2k(ul Uplo, t Transpose, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
+	Dtrmm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int)
+	Dtrsm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int)
 }
 
 // Complex64 implements the single precision complex BLAS routines.
@@ -307,36 +300,36 @@ type Complex64Level1 interface {
 
 // Complex64Level2 implements the single precision complex BLAS routines Level 2 routines.
 type Complex64Level2 interface {
-	Cgemv(o Order, tA Transpose, m, n int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
-	Cgbmv(o Order, tA Transpose, m, n, kL, kU int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
-	Ctrmv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []complex64, lda int, x []complex64, incX int)
-	Ctbmv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []complex64, lda int, x []complex64, incX int)
-	Ctpmv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []complex64, x []complex64, incX int)
-	Ctrsv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []complex64, lda int, x []complex64, incX int)
-	Ctbsv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []complex64, lda int, x []complex64, incX int)
-	Ctpsv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []complex64, x []complex64, incX int)
-	Chemv(o Order, ul Uplo, n int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
-	Chbmv(o Order, ul Uplo, n, k int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
-	Chpmv(o Order, ul Uplo, n int, alpha complex64, ap []complex64, x []complex64, incX int, beta complex64, y []complex64, incY int)
-	Cgeru(o Order, m, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, a []complex64, lda int)
-	Cgerc(o Order, m, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, a []complex64, lda int)
-	Cher(o Order, ul Uplo, n int, alpha float32, x []complex64, incX int, a []complex64, lda int)
-	Chpr(o Order, ul Uplo, n int, alpha float32, x []complex64, incX int, a []complex64)
-	Cher2(o Order, ul Uplo, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, a []complex64, lda int)
-	Chpr2(o Order, ul Uplo, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, ap []complex64)
+	Cgemv(tA Transpose, m, n int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
+	Cgbmv(tA Transpose, m, n, kL, kU int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
+	Ctrmv(ul Uplo, tA Transpose, d Diag, n int, a []complex64, lda int, x []complex64, incX int)
+	Ctbmv(ul Uplo, tA Transpose, d Diag, n, k int, a []complex64, lda int, x []complex64, incX int)
+	Ctpmv(ul Uplo, tA Transpose, d Diag, n int, ap []complex64, x []complex64, incX int)
+	Ctrsv(ul Uplo, tA Transpose, d Diag, n int, a []complex64, lda int, x []complex64, incX int)
+	Ctbsv(ul Uplo, tA Transpose, d Diag, n, k int, a []complex64, lda int, x []complex64, incX int)
+	Ctpsv(ul Uplo, tA Transpose, d Diag, n int, ap []complex64, x []complex64, incX int)
+	Chemv(ul Uplo, n int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
+	Chbmv(ul Uplo, n, k int, alpha complex64, a []complex64, lda int, x []complex64, incX int, beta complex64, y []complex64, incY int)
+	Chpmv(ul Uplo, n int, alpha complex64, ap []complex64, x []complex64, incX int, beta complex64, y []complex64, incY int)
+	Cgeru(m, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, a []complex64, lda int)
+	Cgerc(m, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, a []complex64, lda int)
+	Cher(ul Uplo, n int, alpha float32, x []complex64, incX int, a []complex64, lda int)
+	Chpr(ul Uplo, n int, alpha float32, x []complex64, incX int, a []complex64)
+	Cher2(ul Uplo, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, a []complex64, lda int)
+	Chpr2(ul Uplo, n int, alpha complex64, x []complex64, incX int, y []complex64, incY int, ap []complex64)
 }
 
 // Complex64Level3 implements the single precision complex BLAS Level 3 routines.
 type Complex64Level3 interface {
-	Cgemm(o Order, tA, tB Transpose, m, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
-	Csymm(o Order, s Side, ul Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
-	Csyrk(o Order, ul Uplo, t Transpose, n, k int, alpha complex64, a []complex64, lda int, beta complex64, c []complex64, ldc int)
-	Csyr2k(o Order, ul Uplo, t Transpose, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
-	Ctrmm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int)
-	Ctrsm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int)
-	Chemm(o Order, s Side, ul Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
-	Cherk(o Order, ul Uplo, t Transpose, n, k int, alpha float32, a []complex64, lda int, beta float32, c []complex64, ldc int)
-	Cher2k(o Order, ul Uplo, t Transpose, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta float32, c []complex64, ldc int)
+	Cgemm(tA, tB Transpose, m, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
+	Csymm(s Side, ul Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
+	Csyrk(ul Uplo, t Transpose, n, k int, alpha complex64, a []complex64, lda int, beta complex64, c []complex64, ldc int)
+	Csyr2k(ul Uplo, t Transpose, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
+	Ctrmm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int)
+	Ctrsm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int)
+	Chemm(s Side, ul Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int)
+	Cherk(ul Uplo, t Transpose, n, k int, alpha float32, a []complex64, lda int, beta float32, c []complex64, ldc int)
+	Cher2k(ul Uplo, t Transpose, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta float32, c []complex64, ldc int)
 }
 
 // Complex128 implements the double precision complex BLAS routines.
@@ -362,34 +355,34 @@ type Complex128Level1 interface {
 
 // Complex128Level2 implements the double precision complex BLAS Level 2 routines.
 type Complex128Level2 interface {
-	Zgemv(o Order, tA Transpose, m, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
-	Zgbmv(o Order, tA Transpose, m, n int, kL int, kU int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
-	Ztrmv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []complex128, lda int, x []complex128, incX int)
-	Ztbmv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []complex128, lda int, x []complex128, incX int)
-	Ztpmv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []complex128, x []complex128, incX int)
-	Ztrsv(o Order, ul Uplo, tA Transpose, d Diag, n int, a []complex128, lda int, x []complex128, incX int)
-	Ztbsv(o Order, ul Uplo, tA Transpose, d Diag, n, k int, a []complex128, lda int, x []complex128, incX int)
-	Ztpsv(o Order, ul Uplo, tA Transpose, d Diag, n int, ap []complex128, x []complex128, incX int)
-	Zhemv(o Order, ul Uplo, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
-	Zhbmv(o Order, ul Uplo, n, k int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
-	Zhpmv(o Order, ul Uplo, n int, alpha complex128, ap []complex128, x []complex128, incX int, beta complex128, y []complex128, incY int)
-	Zgeru(o Order, m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int)
-	Zgerc(o Order, m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int)
-	Zher(o Order, ul Uplo, n int, alpha float64, x []complex128, incX int, a []complex128, lda int)
-	Zhpr(o Order, ul Uplo, n int, alpha float64, x []complex128, incX int, a []complex128)
-	Zher2(o Order, ul Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int)
-	Zhpr2(o Order, ul Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, ap []complex128)
+	Zgemv(tA Transpose, m, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
+	Zgbmv(tA Transpose, m, n int, kL int, kU int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
+	Ztrmv(ul Uplo, tA Transpose, d Diag, n int, a []complex128, lda int, x []complex128, incX int)
+	Ztbmv(ul Uplo, tA Transpose, d Diag, n, k int, a []complex128, lda int, x []complex128, incX int)
+	Ztpmv(ul Uplo, tA Transpose, d Diag, n int, ap []complex128, x []complex128, incX int)
+	Ztrsv(ul Uplo, tA Transpose, d Diag, n int, a []complex128, lda int, x []complex128, incX int)
+	Ztbsv(ul Uplo, tA Transpose, d Diag, n, k int, a []complex128, lda int, x []complex128, incX int)
+	Ztpsv(ul Uplo, tA Transpose, d Diag, n int, ap []complex128, x []complex128, incX int)
+	Zhemv(ul Uplo, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
+	Zhbmv(ul Uplo, n, k int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int)
+	Zhpmv(ul Uplo, n int, alpha complex128, ap []complex128, x []complex128, incX int, beta complex128, y []complex128, incY int)
+	Zgeru(m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int)
+	Zgerc(m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int)
+	Zher(ul Uplo, n int, alpha float64, x []complex128, incX int, a []complex128, lda int)
+	Zhpr(ul Uplo, n int, alpha float64, x []complex128, incX int, a []complex128)
+	Zher2(ul Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int)
+	Zhpr2(ul Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, ap []complex128)
 }
 
 // Complex128Level3 implements the double precision complex BLAS Level 3 routines.
 type Complex128Level3 interface {
-	Zgemm(o Order, tA, tB Transpose, m, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
-	Zsymm(o Order, s Side, ul Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
-	Zsyrk(o Order, ul Uplo, t Transpose, n, k int, alpha complex128, a []complex128, lda int, beta complex128, c []complex128, ldc int)
-	Zsyr2k(o Order, ul Uplo, t Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
-	Ztrmm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int)
-	Ztrsm(o Order, s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int)
-	Zhemm(o Order, s Side, ul Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
-	Zherk(o Order, ul Uplo, t Transpose, n, k int, alpha float64, a []complex128, lda int, beta float64, c []complex128, ldc int)
-	Zher2k(o Order, ul Uplo, t Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta float64, c []complex128, ldc int)
+	Zgemm(tA, tB Transpose, m, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
+	Zsymm(s Side, ul Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
+	Zsyrk(ul Uplo, t Transpose, n, k int, alpha complex128, a []complex128, lda int, beta complex128, c []complex128, ldc int)
+	Zsyr2k(ul Uplo, t Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
+	Ztrmm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int)
+	Ztrsm(s Side, ul Uplo, tA Transpose, d Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int)
+	Zhemm(s Side, ul Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int)
+	Zherk(ul Uplo, t Transpose, n, k int, alpha float64, a []complex128, lda int, beta float64, c []complex128, ldc int)
+	Zher2k(ul Uplo, t Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta float64, c []complex128, ldc int)
 }

--- a/cblas/genBlas.pl
+++ b/cblas/genBlas.pl
@@ -69,6 +69,15 @@ var (
 	_ blas.Complex128 = Blas{}
 )
 
+// Type order is used to specify the matrix storage format. We still interact with
+// an API that allows client calls to specify order, so this is here to document that fact.
+type order int
+
+const (
+	rowMajor order = 101 + iota
+	colMajor
+)
+
 func max(a, b int) int {
 	if a > b {
 		return a
@@ -339,6 +348,7 @@ sub processParamToGo {
 	my $complexType = shift;
 	my @processed;
 	my @params = split ',', $paramList;
+	my $skip = 0;
 	foreach my $param (@params) {
 		my @parts = split /[ *]/, $param;
 		my $var = lcfirst $parts[scalar @parts - 1];
@@ -376,10 +386,7 @@ sub processParamToGo {
 			push @processed, $var." float64"; next;
 		};
 		$param =~ m/^const enum/ && do {
-			$var eq "order" && do {
-				$var = "o";
-				push @processed, $var." blas.Order"; next;
-			};
+			$var eq "order" && $skip++;
 			$var =~ /trans/ && do {
 				$var =~ s/trans([AB]?)/t$1/;
 				push @processed, $var." blas.Transpose"; next;
@@ -398,7 +405,7 @@ sub processParamToGo {
 			};
 		};
 	}
-	die "missed Go parameters from '$func', '$paramList'" if scalar @processed != scalar @params;
+	die "missed Go parameters from '$func', '$paramList'" if scalar @processed+$skip != scalar @params;
 	return join ", ", @processed;
 }
 
@@ -430,7 +437,6 @@ sub processParamToChecks {
 		$param =~ m/^const enum [a-zA-Z]/ && do {
 			$var eq "order" && do {
 				$scalarArgs{'o'} = 1;
-				push @processed, "if o != blas.RowMajor && o != blas.ColMajor { panic(\"cblas: illegal order\") }"; next;
 			};
 			$var =~ /trans/ && do {
 				$var =~ s/trans([AB]?)/t$1/;
@@ -497,25 +503,13 @@ sub processParamToChecks {
 					push @processed, "} else {";
 					push @processed, "if lda*(m-1)+n > len(a) || lda < max(1, n) { panic(\"cblas: index of a out of range\") }";
 					push @processed, "}";
-					push @processed, "if o == blas.RowMajor {";
 					push @processed, "if ldb*(m-1)+n > len(b) || ldb < max(1, n) { panic(\"cblas: index of b out of range\") }";
-					push @processed, "} else {";
-					push @processed, "if ldb*(n-1)+m > len(b) || ldb < max(1, m) { panic(\"cblas: index of b out of range\") }";
-					push @processed, "}";
 			} elsif (($scalarArgs{'kL'} && $scalarArgs{'kU'}) || $scalarArgs{'m'}) {
-				push @processed, "if o == blas.RowMajor {";
 				if ($scalarArgs{'kL'} && $scalarArgs{'kU'}) {
 					push @processed, "if lda*(m-1)+kL+kU+1 > len(a) || lda < kL+kU+1 { panic(\"cblas: index of a out of range\") }";
 				} else {
 					push @processed, "if lda*(m-1)+n > len(a) || lda < max(1, n) { panic(\"cblas: index of a out of range\") }";
 				}
-				push @processed, "} else {";
-				if ($scalarArgs{'kL'} && $scalarArgs{'kU'}) {
-					push @processed, "if lda*(n-1)+kL+kU+1 > len(a) || lda < kL+kU+1 { panic(\"cblas: index of a out of range\") }";
-				} else {
-					push @processed, "if lda*(n-1)+m > len(a) || lda < max(1, m) { panic(\"cblas: index of a out of range\") }";
-				}
-				push @processed, "}";
 			} else {
 				if ($scalarArgs{'k'}) {
 					push @processed, "if lda*(n-1)+k+1 > len(a) || lda < k+1 { panic(\"cblas: index of a out of range\") }";
@@ -529,34 +523,19 @@ sub processParamToChecks {
 			push @processed, "var k int";
 			push @processed, "if s == blas.Left { k = m } else { k = n }";
 			push @processed, "if lda*(k-1)+k > len(a) || lda < max(1, k) { panic(\"cblas: index of a out of range\") }";
-			push @processed, "if o == blas.RowMajor {";
 			push @processed, "if ldb*(m-1)+n > len(b) || ldb < max(1, n) { panic(\"cblas: index of b out of range\") }";
 			if ($arrayArgs{'c'}) {
 				push @processed, "if ldc*(m-1)+n > len(c) || ldc < max(1, n) { panic(\"cblas: index of c out of range\") }";
 			}
-			push @processed, "} else {";
-			push @processed, "if ldb*(n-1)+m > len(b) || ldb < max(1, m) { panic(\"cblas: index of b out of range\") }";
-			if ($arrayArgs{'c'}) {
-				push @processed, "if ldc*(n-1)+m > len(c) || ldc < max(1, m) { panic(\"cblas: index of c out of range\") }";
-			}
-			push @processed, "}";
 		}
 		if ($scalarArgs{'t'}) {
 			push @processed, "var row, col int";
 			push @processed, "if t == blas.NoTrans { row, col = n, k } else { row, col = k, n }";
-			push @processed, "if o == blas.RowMajor {";
 			foreach my $ref ('a', 'b') {
 				if ($arrayArgs{$ref}) {
 					push @processed, "if ld${ref}*(row-1)+col > len(${ref}) || ld${ref} < max(1, col) { panic(\"cblas: index of ${ref} out of range\") }";
 				}
 			}
-			push @processed, "} else {";
-			foreach my $ref ('a', 'b') {
-				if ($arrayArgs{$ref}) {
-					push @processed, "if ld${ref}*(col-1)+row > len(${ref}) || ld${ref} < max(1, row) { panic(\"cblas: index of ${ref} out of range\") }";
-				}
-			}
-			push @processed, "}";
 			if ($arrayArgs{'c'}) {
 				push @processed, "if ldc*(n-1)+n > len(c) || ldc < max(1, n) { panic(\"cblas: index of c out of range\") }";
 			}
@@ -565,15 +544,9 @@ sub processParamToChecks {
 			push @processed, "var rowA, colA, rowB, colB int";
 			push @processed, "if tA == blas.NoTrans { rowA, colA = m, k } else { rowA, colA = k, m }";
 			push @processed, "if tB == blas.NoTrans { rowB, colB = k, n } else { rowB, colB = n, k }";
-			push @processed, "if o == blas.RowMajor {";
 			push @processed, "if lda*(rowA-1)+colA > len(a) || lda < max(1, colA) { panic(\"cblas: index of a out of range\") }";
 			push @processed, "if ldb*(rowB-1)+colB > len(b) || ldb < max(1, colB) { panic(\"cblas: index of b out of range\") }";
 			push @processed, "if ldc*(m-1)+n > len(c) || ldc < max(1, n) { panic(\"cblas: index of c out of range\") }";
-			push @processed, "} else {";
-			push @processed, "if lda*(colA-1)+rowA > len(a) || lda < max(1, rowA) { panic(\"cblas: index of a out of range\") }";
-			push @processed, "if ldb*(colB-1)+rowB > len(b) || ldb < max(1, rowB) { panic(\"cblas: index of b out of range\") }";
-			push @processed, "if ldc*(n-1)+m > len(c) || ldc < max(1, m) { panic(\"cblas: index of c out of range\") }";
-			push @processed, "}";
 		}
 	}
 
@@ -622,8 +595,7 @@ sub processParamToC {
 		};
 		$param =~ m/^const enum [a-zA-Z]/ && do {
 			$var eq "order" && do {
-				$var = "o";
-				push @processed, "C.enum_$parts[scalar @parts - 2](".$var.")"; next;
+				push @processed, "C.enum_$parts[scalar @parts - 2](rowMajor)"; next;
 			};
 			$var =~ /trans/ && do {
 				$var =~ s/trans([AB]?)/t$1/;

--- a/cblas/level2double_test.go
+++ b/cblas/level2double_test.go
@@ -1,8 +1,9 @@
 package cblas
 
 import (
-	"github.com/gonum/blas/testblas"
 	"testing"
+
+	"github.com/gonum/blas/testblas"
 )
 
 func TestDgemv(t *testing.T) {
@@ -11,12 +12,4 @@ func TestDgemv(t *testing.T) {
 
 func TestDger(t *testing.T) {
 	testblas.DgerTest(t, blasser)
-}
-
-func TestDtxmv(t *testing.T) {
-	testblas.DtxmvTest(t, blasser)
-}
-
-func TestDgbmv(t *testing.T) {
-	testblas.DgbmvTest(t, blasser)
 }

--- a/dbw/level2.go
+++ b/dbw/level2.go
@@ -14,7 +14,7 @@ func Gemv(tA blas.Transpose, alpha float64, A General, x Vector, beta float64, y
 	} else {
 		panic("blas: illegal value for tA")
 	}
-	impl.Dgemv(A.Order, tA, A.Rows, A.Cols, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
+	impl.Dgemv(tA, A.Rows, A.Cols, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
 func Gbmv(tA blas.Transpose, alpha float64, A GeneralBand, x Vector, beta float64, y Vector) {
@@ -29,7 +29,7 @@ func Gbmv(tA blas.Transpose, alpha float64, A GeneralBand, x Vector, beta float6
 	} else {
 		panic("blas: illegal value for tA")
 	}
-	impl.Dgbmv(A.Order, tA, A.Rows, A.Cols, A.KL, A.KU, alpha, A.Data,
+	impl.Dgbmv(tA, A.Rows, A.Cols, A.KL, A.KU, alpha, A.Data,
 		A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
@@ -37,56 +37,56 @@ func Trmv(tA blas.Transpose, A Triangular, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dtrmv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Dtrmv(A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tbmv(tA blas.Transpose, A TriangularBand, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dtbmv(A.Order, A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Dtbmv(A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tpmv(tA blas.Transpose, A TriangularPacked, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dtpmv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
+	impl.Dtpmv(A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
 }
 
 func Trsv(tA blas.Transpose, A Triangular, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dtrsv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Dtrsv(A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tbsv(tA blas.Transpose, A TriangularBand, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dtbsv(A.Order, A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Dtbsv(A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tpsv(tA blas.Transpose, A TriangularPacked, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dtpsv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
+	impl.Dtpsv(A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
 }
 
 func Symv(alpha float64, A Symmetric, x Vector, beta float64, y Vector) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsymv(A.Order, A.Uplo, A.N, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
+	impl.Dsymv(A.Uplo, A.N, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
 func Sbmv(alpha float64, A SymmetricBand, x Vector, beta float64, y Vector) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsbmv(A.Order, A.Uplo, A.N, A.K, alpha, A.Data, A.Stride, x.Data,
+	impl.Dsbmv(A.Uplo, A.N, A.K, alpha, A.Data, A.Stride, x.Data,
 		x.Inc, beta, y.Data, y.Inc)
 }
 
@@ -94,7 +94,7 @@ func Spmv(alpha float64, A SymmetricPacked, x Vector, beta float64, y Vector) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dspmv(A.Order, A.Uplo, A.N, alpha, A.Data, x.Data, x.Inc, beta, y.Data, y.Inc)
+	impl.Dspmv(A.Uplo, A.N, alpha, A.Data, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
 func Ger(alpha float64, x Vector, y Vector, A General) {
@@ -104,33 +104,33 @@ func Ger(alpha float64, x Vector, y Vector, A General) {
 	if y.N != A.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dger(A.Order, A.Rows, A.Cols, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
+	impl.Dger(A.Rows, A.Cols, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
 }
 
 func Syr(alpha float64, x Vector, A Symmetric) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsyr(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data, A.Stride)
+	impl.Dsyr(A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data, A.Stride)
 }
 
 func Spr(alpha float64, x Vector, A SymmetricPacked) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dspr(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data)
+	impl.Dspr(A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data)
 }
 
 func Syr2(alpha float64, x Vector, y Vector, A Symmetric) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsyr2(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
+	impl.Dsyr2(A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
 }
 
 func Spr2(alpha float64, x Vector, y Vector, A SymmetricPacked) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dspr2(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data)
+	impl.Dspr2(A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data)
 }

--- a/dbw/level3.go
+++ b/dbw/level3.go
@@ -26,7 +26,7 @@ func Gemm(tA, tB blas.Transpose, alpha float64, A, B General, beta float64, C Ge
 	if n != C.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dgemm(A.Order, tA, tB, m, n, k, alpha, A.Data, A.Stride,
+	impl.Dgemm(tA, tB, m, n, k, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -51,7 +51,7 @@ func Symm(s blas.Side, alpha float64, A Symmetric, B General, beta float64, C Ge
 	if n != C.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsymm(A.Order, s, A.Uplo, m, n, alpha, A.Data, A.Stride,
+	impl.Dsymm(s, A.Uplo, m, n, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -65,7 +65,7 @@ func Syrk(t blas.Transpose, alpha float64, A General, beta float64, C Symmetric)
 	if n != C.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsyrk(A.Order, C.Uplo, t, n, k, alpha, A.Data, A.Stride, beta,
+	impl.Dsyrk(C.Uplo, t, n, k, alpha, A.Data, A.Stride, beta,
 		C.Data, C.Stride)
 }
 
@@ -85,7 +85,7 @@ func Syr2k(t blas.Transpose, alpha float64, A, B General, beta float64, C Symmet
 	if n != C.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Dsyr2k(A.Order, C.Uplo, t, n, k, alpha, A.Data, A.Stride,
+	impl.Dsyr2k(C.Uplo, t, n, k, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -99,7 +99,7 @@ func Trmm(s blas.Side, tA blas.Transpose, alpha float64, A Triangular, B General
 			panic("blas: dimension mismatch")
 		}
 	}
-	impl.Dtrmm(A.Order, s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
+	impl.Dtrmm(s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
 		B.Data, B.Stride)
 }
 
@@ -113,6 +113,6 @@ func Trsm(s blas.Side, tA blas.Transpose, alpha float64, A Triangular, B General
 			panic("blas: dimension mismatch")
 		}
 	}
-	impl.Dtrsm(A.Order, s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
+	impl.Dtrsm(s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
 		B.Data, B.Stride)
 }

--- a/goblas/level2double_test.go
+++ b/goblas/level2double_test.go
@@ -1,8 +1,9 @@
 package goblas
 
 import (
-	"github.com/gonum/blas/testblas"
 	"testing"
+
+	"github.com/gonum/blas/testblas"
 )
 
 func TestDgemv(t *testing.T) {
@@ -11,12 +12,4 @@ func TestDgemv(t *testing.T) {
 
 func TestDger(t *testing.T) {
 	testblas.DgerTest(t, blasser)
-}
-
-func TestDtxmv(t *testing.T) {
-	testblas.DtxmvTest(t, blasser)
-}
-
-func TestDgbmv(t *testing.T) {
-	testblas.DgbmvTest(t, blasser)
 }

--- a/testblas/aux.go
+++ b/testblas/aux.go
@@ -3,8 +3,6 @@ package testblas
 import (
 	"math"
 	"testing"
-
-	"github.com/gonum/blas"
 )
 
 // throwPanic will throw unexpected panics if true, or will just report them as errors if false
@@ -114,52 +112,28 @@ func sliceCopy(a []float64) []float64 {
 	return n
 }
 
-func flatten(a [][]float64, o blas.Order) []float64 {
+func flatten(a [][]float64) []float64 {
 	if len(a) == 0 {
 		return nil
 	}
 	m := len(a)
 	n := len(a[0])
 	s := make([]float64, m*n)
-	if o == blas.RowMajor {
-		for i := 0; i < m; i++ {
-			for j := 0; j < n; j++ {
-				s[i*n+j] = a[i][j]
-			}
-		}
-		return s
-	}
-	if o == blas.ColMajor {
+	for i := 0; i < m; i++ {
 		for j := 0; j < n; j++ {
-			for i := 0; i < m; i++ {
-				s[j*m+i] = a[i][j]
-			}
+			s[i*n+j] = a[i][j]
 		}
-		return s
 	}
-	return nil
+	return s
 }
 
-func unflatten(a []float64, o blas.Order, m, n int) [][]float64 {
-	if o == blas.RowMajor {
-		s := make([][]float64, m)
-		for i := 0; i < m; i++ {
-			s[i] = make([]float64, n)
-			for j := 0; j < n; j++ {
-				s[i][j] = a[i*n+j]
-			}
+func unflatten(a []float64, m, n int) [][]float64 {
+	s := make([][]float64, m)
+	for i := 0; i < m; i++ {
+		s[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			s[i][j] = a[i*n+j]
 		}
-		return s
 	}
-	if o == blas.ColMajor {
-		s := make([][]float64, m)
-		for i := 0; i < m; i++ {
-			s[i] = make([]float64, n)
-			for j := 0; j < n; j++ {
-				s[i][j] = a[j*m+i]
-			}
-		}
-		return s
-	}
-	return nil
+	return s
 }

--- a/testblas/dgbmv.go
+++ b/testblas/dgbmv.go
@@ -1,15 +1,13 @@
 package testblas
 
-import (
-	"testing"
-
-	"github.com/gonum/blas"
-)
+import "github.com/gonum/blas"
 
 type Dgbmver interface {
-	Dgbmv(o blas.Order, tA blas.Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
+	Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int)
 }
 
+// TODO: Redo this test with row major implementation
+/*
 func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	A := []float64{0, 0, 3, 6, 0, 1, 4, 7, 9, 2, 5, 8}
 	kL := 1
@@ -27,7 +25,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in := make([]float64, len(x1))
 	out := make([]float64, m*incX1)
 	copy(in, x1)
-	blasser.Dgbmv(blas.ColMajor, blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
+	blasser.Dgbmv(blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
 
 	if !dStridedSliceTolEqual(m, out, incX1, solNoTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, NoTrans, IncX==1")
@@ -36,7 +34,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in = make([]float64, len(x2))
 	out = make([]float64, m*incX2)
 	copy(in, x2)
-	blasser.Dgbmv(blas.ColMajor, blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
+	blasser.Dgbmv(blas.NoTrans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
 
 	if !dStridedSliceTolEqual(m, out, incX2, solNoTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, NoTrans, IncX==2")
@@ -47,7 +45,7 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in = make([]float64, len(x1))
 	out = make([]float64, n*incX1)
 	copy(in, x1)
-	blasser.Dgbmv(blas.ColMajor, blas.Trans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
+	blasser.Dgbmv(blas.Trans, m, n, kL, kU, 1, A, m, in, incX1, 0, out, incX1)
 
 	if !dStridedSliceTolEqual(n, out, incX1, solTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, Trans, IncX==1")
@@ -56,10 +54,10 @@ func DgbmvTest(t *testing.T, blasser Dgbmver) {
 	in = make([]float64, len(x2))
 	out = make([]float64, n*incX2)
 	copy(in, x2)
-	blasser.Dgbmv(blas.ColMajor, blas.Trans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
+	blasser.Dgbmv(blas.Trans, m, n, kL, kU, 1, A, m, in, incX2, 0, out, incX2)
 
 	if !dStridedSliceTolEqual(n, out, incX2, solTrans, 1) {
 		t.Error("Wrong Dgbmv result for: ColMajor, Trans, IncX==2")
 	}
-
 }
+*/

--- a/testblas/dgemm.go
+++ b/testblas/dgemm.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Dgemmer interface {
-	Dgemm(o blas.Order, tA, tB blas.Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
+	Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int)
 }
 
 type DgemmCase struct {
@@ -208,52 +208,35 @@ func transpose(a [][]float64) [][]float64 {
 func TestDgemm(t *testing.T, blasser Dgemmer) {
 	for i, test := range DgemmCases {
 		// Test that it passes row major
-		dgemmcomp(i, "RowMajorNoTrans", t, blasser, blas.RowMajor, blas.NoTrans, blas.NoTrans,
-			test.m, test.n, test.k, test.alpha, test.beta, test.a, test.b, test.c, test.ans)
-		// Test that it passes normal col major
-		dgemmcomp(i, "ColMajorNoTrans", t, blasser, blas.ColMajor, blas.NoTrans, blas.NoTrans,
+		dgemmcomp(i, "RowMajorNoTrans", t, blasser, blas.NoTrans, blas.NoTrans,
 			test.m, test.n, test.k, test.alpha, test.beta, test.a, test.b, test.c, test.ans)
 		// Try with A transposed
-		dgemmcomp(i, "RowMajorTransA", t, blasser, blas.RowMajor, blas.Trans, blas.NoTrans,
-			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), test.b, test.c, test.ans)
-		dgemmcomp(i, "ColMajorTransA", t, blasser, blas.ColMajor, blas.Trans, blas.NoTrans,
+		dgemmcomp(i, "RowMajorTransA", t, blasser, blas.Trans, blas.NoTrans,
 			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), test.b, test.c, test.ans)
 		// Try with B transposed
-		dgemmcomp(i, "RowMajorTransB", t, blasser, blas.RowMajor, blas.NoTrans, blas.Trans,
-			test.m, test.n, test.k, test.alpha, test.beta, test.a, transpose(test.b), test.c, test.ans)
-		dgemmcomp(i, "ColMajorTransB", t, blasser, blas.ColMajor, blas.NoTrans, blas.Trans,
+		dgemmcomp(i, "RowMajorTransB", t, blasser, blas.NoTrans, blas.Trans,
 			test.m, test.n, test.k, test.alpha, test.beta, test.a, transpose(test.b), test.c, test.ans)
 		// Try with both transposed
-		dgemmcomp(i, "RowMajorTransBoth", t, blasser, blas.RowMajor, blas.Trans, blas.Trans,
-			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), transpose(test.b), test.c, test.ans)
-		dgemmcomp(i, "ColMajorTransBoth", t, blasser, blas.ColMajor, blas.Trans, blas.Trans,
+		dgemmcomp(i, "RowMajorTransBoth", t, blasser, blas.Trans, blas.Trans,
 			test.m, test.n, test.k, test.alpha, test.beta, transpose(test.a), transpose(test.b), test.c, test.ans)
 	}
 }
 
-func dgemmcomp(i int, name string, t *testing.T, blasser Dgemmer, o blas.Order, tA, tB blas.Transpose, m, n, k int,
+func dgemmcomp(i int, name string, t *testing.T, blasser Dgemmer, tA, tB blas.Transpose, m, n, k int,
 	alpha, beta float64, a [][]float64, b [][]float64, c [][]float64, ans [][]float64) {
 
-	aFlat := flatten(a, o)
-	aCopy := flatten(a, o)
-	bFlat := flatten(b, o)
-	bCopy := flatten(b, o)
-	cFlat := flatten(c, o)
-	ansFlat := flatten(ans, o)
-
-	var lda, ldb, ldc int
-	if o == blas.RowMajor {
-		lda = len(a[0])
-		ldb = len(b[0])
-		ldc = len(c[0])
-	} else {
-		lda = len(a)
-		ldb = len(b)
-		ldc = len(c)
-	}
+	aFlat := flatten(a)
+	aCopy := flatten(a)
+	bFlat := flatten(b)
+	bCopy := flatten(b)
+	cFlat := flatten(c)
+	ansFlat := flatten(ans)
+	lda := len(a[0])
+	ldb := len(b[0])
+	ldc := len(c[0])
 
 	// Compute the matrix multiplication
-	blasser.Dgemm(o, tA, tB, m, n, k, alpha, aFlat, lda, bFlat, ldb, beta, cFlat, ldc)
+	blasser.Dgemm(tA, tB, m, n, k, alpha, aFlat, lda, bFlat, ldb, beta, cFlat, ldc)
 
 	if !dSliceEqual(aFlat, aCopy) {
 		t.Errorf("Test %v case %v: a changed during call to Dgemm", i, name)

--- a/testblas/dger.go
+++ b/testblas/dger.go
@@ -1,13 +1,9 @@
 package testblas
 
-import (
-	"testing"
-
-	"github.com/gonum/blas"
-)
+import "testing"
 
 type Dgerer interface {
-	Dger(o blas.Order, m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
+	Dger(m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int)
 }
 
 func DgerTest(t *testing.T, blasser Dgerer) {
@@ -55,7 +51,6 @@ func DgerTest(t *testing.T, blasser Dgerer) {
 			incX:    1,
 			incY:    1,
 			trueAns: [][]float64{{3.5, -7.6, 3.5}, {5.9, -12.2, 3.3}, {-1.3, -4.3, -9.7}},
-			//trueAns: [][]float64{{3.5, -2, 2.8}, {5.9, -27, -4.3}, {-1.3, 2.4, 9}},
 		},
 
 		{
@@ -131,19 +126,17 @@ func DgerTest(t *testing.T, blasser Dgerer) {
 		a := sliceOfSliceCopy(test.a)
 
 		// Test with row major
-		o := blas.RowMajor
 		alpha := 1.0
-		aFlat := flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
-		ans := unflatten(aFlat, o, test.m, test.n)
+		aFlat := flatten(a)
+		blasser.Dger(test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
+		ans := unflatten(aFlat, test.m, test.n)
 		dgercomp(t, x, test.x, y, test.y, ans, test.trueAns, test.name+" row maj")
 
 		// Test with different alpha
-		o = blas.RowMajor
 		alpha = 4.0
-		aFlat = flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
-		ans = unflatten(aFlat, o, test.m, test.n)
+		aFlat = flatten(a)
+		blasser.Dger(test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.n)
+		ans = unflatten(aFlat, test.m, test.n)
 		trueCopy := sliceOfSliceCopy(test.trueAns)
 		for i := range trueCopy {
 			for j := range trueCopy[i] {
@@ -151,30 +144,6 @@ func DgerTest(t *testing.T, blasser Dgerer) {
 			}
 		}
 		dgercomp(t, x, test.x, y, test.y, ans, trueCopy, test.name+" row maj alpha")
-
-		// Test with col major
-		o = blas.ColMajor
-		alpha = 1.0
-		aFlat = flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.m)
-		//fmt.Println("col maj ans", aFlat)
-		ans = unflatten(aFlat, o, test.m, test.n)
-		dgercomp(t, x, test.x, y, test.y, ans, test.trueAns, test.name+" col maj")
-
-		// Test with different alpha
-		o = blas.ColMajor
-		alpha = -4.0
-		aFlat = flatten(a, o)
-		blasser.Dger(o, test.m, test.n, alpha, x, test.incX, y, test.incY, aFlat, test.m)
-		ans = unflatten(aFlat, o, test.m, test.n)
-		trueCopy = sliceOfSliceCopy(test.trueAns)
-		for i := range trueCopy {
-			for j := range trueCopy[i] {
-				trueCopy[i][j] = alpha*(trueCopy[i][j]-a[i][j]) + a[i][j]
-			}
-		}
-		dgercomp(t, x, test.x, y, test.y, ans, trueCopy, test.name+" col maj alpha")
-
 	}
 }
 

--- a/testblas/dtrsm.go
+++ b/testblas/dtrsm.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Dtrsmer interface {
-	Dtrsm(o blas.Order, s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag,
+	Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag,
 		m, n int, alpha float64, a []float64, lda int, b []float64, ldb int)
 }
 
@@ -75,19 +75,17 @@ func TestDtrsm(t *testing.T, blasser Dtrsmer) {
 			panics: true,
 		},
 	} {
-		const (
-			name = "RowMajor"
-			o    = blas.RowMajor
-		)
 
-		aFlat := flatten(test.a, o)
-		aCopy := flatten(test.a, o)
-		bFlat := flatten(test.b, o)
-		ansFlat := flatten(test.ans, o)
+		const name = "RowMajor"
+
+		aFlat := flatten(test.a)
+		aCopy := flatten(test.a)
+		bFlat := flatten(test.b)
+		ansFlat := flatten(test.ans)
 
 		fn := func() {
 			blasser.Dtrsm(
-				o, test.s, test.ul, test.tA, test.d,
+				test.s, test.ul, test.tA, test.d,
 				test.m, test.n,
 				test.alpha,
 				aFlat, test.lda,

--- a/testblas/dtxmv.go
+++ b/testblas/dtxmv.go
@@ -1,15 +1,11 @@
 package testblas
 
-import (
-	"testing"
-
-	"github.com/gonum/blas"
-)
+import "github.com/gonum/blas"
 
 type Dtxmver interface {
-	Dtrmv(o blas.Order, ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int)
-	Dtbmv(o blas.Order, ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int)
-	Dtpmv(o blas.Order, ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, x []float64, incX int)
+	Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int)
+	Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int)
+	Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, x []float64, incX int)
 }
 
 type vec struct {
@@ -97,6 +93,8 @@ var cases = []struct {
 	},
 }
 
+// TODO: Replace this testing code with RowMajor code
+/*
 func DtxmvTest(t *testing.T, blasser Dtxmver) {
 
 	for nc, c := range cases {
@@ -151,3 +149,4 @@ func DtxmvTest(t *testing.T, blasser Dtxmver) {
 		}
 	}
 }
+*/

--- a/zbw/level2.go
+++ b/zbw/level2.go
@@ -15,7 +15,7 @@ func Gemv(tA blas.Transpose, alpha complex128, A General, x Vector, beta complex
 		panic("blas: illegal value for tA")
 	}
 
-	impl.Zgemv(A.Order, tA, A.Rows, A.Cols, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
+	impl.Zgemv(tA, A.Rows, A.Cols, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
 func Gbmv(tA blas.Transpose, alpha complex128, A GeneralBand, x Vector, beta complex128, y Vector) {
@@ -30,7 +30,7 @@ func Gbmv(tA blas.Transpose, alpha complex128, A GeneralBand, x Vector, beta com
 	} else {
 		panic("blas: illegal value for tA")
 	}
-	impl.Zgbmv(A.Order, tA, A.Rows, A.Cols, A.KL, A.KU, alpha, A.Data,
+	impl.Zgbmv(tA, A.Rows, A.Cols, A.KL, A.KU, alpha, A.Data,
 		A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
@@ -38,55 +38,55 @@ func Trmv(tA blas.Transpose, A Triangular, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Ztrmv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Ztrmv(A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tbmv(tA blas.Transpose, A TriangularBand, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Ztbmv(A.Order, A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Ztbmv(A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tpmv(tA blas.Transpose, A TriangularPacked, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Ztpmv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
+	impl.Ztpmv(A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
 }
 
 func Trsv(tA blas.Transpose, A Triangular, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Ztrsv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Ztrsv(A.Uplo, tA, A.Diag, A.N, A.Data, A.Stride, x.Data, x.Inc)
 }
 
 func Tbsv(tA blas.Transpose, A TriangularBand, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Ztbsv(A.Order, A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
+	impl.Ztbsv(A.Uplo, tA, A.Diag, A.N, A.K, A.Data, A.Stride, x.Data, x.Inc)
 }
 func Tpsv(tA blas.Transpose, A TriangularPacked, x Vector) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Ztpsv(A.Order, A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
+	impl.Ztpsv(A.Uplo, tA, A.Diag, A.N, A.Data, x.Data, x.Inc)
 }
 
 func Hemv(alpha complex128, A Hermitian, x Vector, beta complex128, y Vector) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zhemv(A.Order, A.Uplo, A.N, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
+	impl.Zhemv(A.Uplo, A.N, alpha, A.Data, A.Stride, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
 func Hbmv(alpha complex128, A HermitianBand, x Vector, beta complex128, y Vector) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zhbmv(A.Order, A.Uplo, A.N, A.K, alpha, A.Data, A.Stride, x.Data,
+	impl.Zhbmv(A.Uplo, A.N, A.K, alpha, A.Data, A.Stride, x.Data,
 		x.Inc, beta, y.Data, y.Inc)
 }
 
@@ -94,47 +94,47 @@ func Hpmv(alpha complex128, A HermitianPacked, x Vector, beta complex128, y Vect
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zhpmv(A.Order, A.Uplo, A.N, alpha, A.Data, x.Data, x.Inc, beta, y.Data, y.Inc)
+	impl.Zhpmv(A.Uplo, A.N, alpha, A.Data, x.Data, x.Inc, beta, y.Data, y.Inc)
 }
 
 func Zgerc(alpha complex128, x Vector, y Vector, A General) {
 	if x.N != A.Rows || y.N != A.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zgerc(A.Order, A.Rows, A.Cols, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
+	impl.Zgerc(A.Rows, A.Cols, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
 }
 
 func Zgeru(alpha complex128, x Vector, y Vector, A General) {
 	if x.N != A.Rows || y.N != A.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zgeru(A.Order, A.Rows, A.Cols, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
+	impl.Zgeru(A.Rows, A.Cols, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
 }
 
 func Zher(alpha float64, x Vector, A Hermitian) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zher(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data, A.Stride)
+	impl.Zher(A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data, A.Stride)
 }
 
 func Zhpr(alpha float64, x Vector, A HermitianPacked) {
 	if x.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zhpr(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data)
+	impl.Zhpr(A.Uplo, A.N, alpha, x.Data, x.Inc, A.Data)
 }
 
 func Zher2(alpha complex128, x Vector, y Vector, A Hermitian) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zher2(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
+	impl.Zher2(A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data, A.Stride)
 }
 
 func Zhpr2(alpha complex128, x Vector, y Vector, A HermitianPacked) {
 	if x.N != A.N || y.N != A.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zhpr2(A.Order, A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data)
+	impl.Zhpr2(A.Uplo, A.N, alpha, x.Data, x.Inc, y.Data, y.Inc, A.Data)
 }

--- a/zbw/level3.go
+++ b/zbw/level3.go
@@ -26,7 +26,7 @@ func Gemm(tA, tB blas.Transpose, alpha complex128, A, B General, beta complex128
 	if n != C.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zgemm(A.Order, tA, tB, m, n, k, alpha, A.Data, A.Stride,
+	impl.Zgemm(tA, tB, m, n, k, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -51,7 +51,7 @@ func Symm(s blas.Side, alpha complex128, A Symmetric, B General, beta complex128
 	if n != C.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zsymm(A.Order, s, A.Uplo, m, n, alpha, A.Data, A.Stride,
+	impl.Zsymm(s, A.Uplo, m, n, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -65,7 +65,7 @@ func Syrk(t blas.Transpose, alpha complex128, A General, beta complex128, C Symm
 	if n != C.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zsyrk(A.Order, C.Uplo, t, n, k, alpha, A.Data, A.Stride, beta,
+	impl.Zsyrk(C.Uplo, t, n, k, alpha, A.Data, A.Stride, beta,
 		C.Data, C.Stride)
 }
 
@@ -85,7 +85,7 @@ func Syr2k(t blas.Transpose, alpha complex128, A, B General, beta complex128, C 
 	if n != C.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zsyr2k(A.Order, C.Uplo, t, n, k, alpha, A.Data, A.Stride,
+	impl.Zsyr2k(C.Uplo, t, n, k, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -99,7 +99,7 @@ func Trmm(s blas.Side, tA blas.Transpose, alpha complex128, A Triangular, B Gene
 			panic("blas: dimension mismatch")
 		}
 	}
-	impl.Ztrmm(A.Order, s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
+	impl.Ztrmm(s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
 		B.Data, B.Stride)
 }
 
@@ -113,7 +113,7 @@ func Trsm(s blas.Side, tA blas.Transpose, alpha complex128, A Triangular, B Gene
 			panic("blas: dimension mismatch")
 		}
 	}
-	impl.Ztrsm(A.Order, s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
+	impl.Ztrsm(s, A.Uplo, tA, A.Diag, B.Rows, B.Cols, alpha, A.Data, A.Stride,
 		B.Data, B.Stride)
 }
 
@@ -138,7 +138,7 @@ func Hemm(s blas.Side, alpha complex128, A Hermitian, B General, beta complex128
 	if n != C.Cols {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zhemm(A.Order, s, A.Uplo, m, n, alpha, A.Data, A.Stride,
+	impl.Zhemm(s, A.Uplo, m, n, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }
 
@@ -152,7 +152,7 @@ func Herk(t blas.Transpose, alpha float64, A General, beta float64, C Hermitian)
 	if n != C.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zherk(A.Order, C.Uplo, t, n, k, alpha, A.Data, A.Stride, beta,
+	impl.Zherk(C.Uplo, t, n, k, alpha, A.Data, A.Stride, beta,
 		C.Data, C.Stride)
 }
 
@@ -172,6 +172,6 @@ func Her2k(t blas.Transpose, alpha complex128, A, B General, beta float64, C Her
 	if n != C.N {
 		panic("blas: dimension mismatch")
 	}
-	impl.Zher2k(A.Order, C.Uplo, t, n, k, alpha, A.Data, A.Stride,
+	impl.Zher2k(C.Uplo, t, n, k, alpha, A.Data, A.Stride,
 		B.Data, B.Stride, beta, C.Data, C.Stride)
 }

--- a/zbw/types.go
+++ b/zbw/types.go
@@ -3,6 +3,7 @@ package zbw
 import (
 	"errors"
 	"fmt"
+
 	"github.com/gonum/blas"
 )
 
@@ -18,32 +19,23 @@ func Allocate(dims ...int) []complex128 {
 }
 
 type General struct {
-	Order      blas.Order
 	Rows, Cols int
 	Stride     int
 	Data       []complex128
 }
 
-func NewGeneral(o blas.Order, m, n int, data []complex128) General {
+func NewGeneral(m, n int, data []complex128) General {
 	var A General
 	if data == nil {
 		data = make([]complex128, m*n)
 	}
-	if o == blas.RowMajor {
-		A = General{o, m, n, n, data}
-	} else {
-		A = General{o, m, n, m, data}
-	}
+	A = General{m, n, n, data}
 	must(A.Check())
 	return A
 }
 
 func (A General) Index(i, j int) int {
-	if A.Order == blas.RowMajor {
-		return i*A.Stride + j
-	} else {
-		return i + j*A.Stride
-	}
+	return i*A.Stride + j
 }
 
 func (A General) Check() error {
@@ -56,22 +48,11 @@ func (A General) Check() error {
 	if A.Stride < 1 {
 		return errors.New("blas: illegal stride")
 	}
-	if A.Order == blas.ColMajor {
-		if A.Stride < A.Rows {
-			return errors.New("blas: illegal stride")
-		}
-		if (A.Cols-1)*A.Stride+A.Rows > len(A.Data) {
-			return errors.New("blas: insufficient amount of data")
-		}
-	} else if A.Order == blas.RowMajor {
-		if A.Stride < A.Cols {
-			return errors.New("blas: illegal stride")
-		}
-		if (A.Rows-1)*A.Stride+A.Cols > len(A.Data) {
-			return errors.New("blas: insufficient amount of data")
-		}
-	} else {
-		return errors.New("blas: illegal order")
+	if A.Stride < A.Cols {
+		return errors.New("blas: illegal stride")
+	}
+	if (A.Rows-1)*A.Stride+A.Cols > len(A.Data) {
+		return errors.New("blas: insufficient amount of data")
 	}
 	return nil
 }
@@ -80,24 +61,14 @@ func (A General) Row(i int) Vector {
 	if i >= A.Rows || i < 0 {
 		panic("blas: index out of range")
 	}
-	if A.Order == blas.RowMajor {
-		return Vector{A.Data[A.Stride*i:], A.Cols, 1}
-	} else if A.Order == blas.ColMajor {
-		return Vector{A.Data[i:], A.Cols, A.Stride}
-	}
-	panic("blas: illegal order")
+	return Vector{A.Data[A.Stride*i:], A.Cols, 1}
 }
 
 func (A General) Col(i int) Vector {
 	if i >= A.Cols || i < 0 {
 		panic("blas: index out of range")
 	}
-	if A.Order == blas.RowMajor {
-		return Vector{A.Data[i:], A.Rows, A.Stride}
-	} else if A.Order == blas.ColMajor {
-		return Vector{A.Data[A.Stride*i:], A.Rows, 1}
-	}
-	panic("blas: illegal order")
+	return Vector{A.Data[i:], A.Rows, A.Stride}
 }
 
 func (A General) Sub(i, j, r, c int) General {
@@ -111,17 +82,15 @@ func (A General) Sub(i, j, r, c int) General {
 	if r < 0 || c < 0 {
 		panic("blas: r < 0 or c < 0")
 	}
-	return General{A.Order, r, c, A.Stride, A.Data[A.Index(i, j):]}
+	return General{r, c, A.Stride, A.Data[A.Index(i, j):]}
 }
 
 type GeneralBand struct {
-	Order blas.Order
 	General
 	KL, KU int
 }
 
 type Triangular struct {
-	Order  blas.Order
 	Data   []complex128
 	N      int
 	Stride int
@@ -130,7 +99,6 @@ type Triangular struct {
 }
 
 type TriangularBand struct {
-	Order  blas.Order
 	Data   []complex128
 	N, K   int
 	Stride int
@@ -139,39 +107,34 @@ type TriangularBand struct {
 }
 
 type TriangularPacked struct {
-	Order blas.Order
-	Data  []complex128
-	N     int
-	Uplo  blas.Uplo
-	Diag  blas.Diag
+	Data []complex128
+	N    int
+	Uplo blas.Uplo
+	Diag blas.Diag
 }
 
 type Symmetric struct {
-	Order     blas.Order
 	Data      []complex128
 	N, Stride int
 	Uplo      blas.Uplo
 }
 
 type Hermitian struct {
-	Order     blas.Order
 	Data      []complex128
 	N, Stride int
 	Uplo      blas.Uplo
 }
 
 type HermitianBand struct {
-	Order        blas.Order
 	Data         []complex128
 	N, K, Stride int
 	Uplo         blas.Uplo
 }
 
 type HermitianPacked struct {
-	Order blas.Order
-	Data  []complex128
-	N     int
-	Uplo  blas.Uplo
+	Data []complex128
+	N    int
+	Uplo blas.Uplo
 }
 
 type Vector struct {
@@ -212,7 +175,7 @@ func Ge2Tr(A General, d blas.Diag, ul blas.Uplo) Triangular {
 	if A.Cols < n {
 		n = A.Cols
 	}
-	return Triangular{A.Order, A.Data, n, A.Stride, ul, d}
+	return Triangular{A.Data, n, A.Stride, ul, d}
 }
 
 func Ge2He(A General, ul blas.Uplo) Hermitian {
@@ -220,7 +183,7 @@ func Ge2He(A General, ul blas.Uplo) Hermitian {
 	if A.Cols < n {
 		n = A.Cols
 	}
-	return Hermitian{A.Order, A.Data, n, A.Stride, ul}
+	return Hermitian{A.Data, n, A.Stride, ul}
 }
 
 func must(err error) {


### PR DESCRIPTION
It was decided, after discussion on the gonum-dev list, to remove
support for column-major matrices in the blas package. This commit
completely removes all public support for the blas interface. Some
necessary residuals remain in the cblas package because the c functions
require specifying an order. However, these residuals are private and
are thus invisible to package users.

Several of the testing scripts tested column major implementation only.
This commit comments out those tests for the time being until they can
be migrated to row major.
