### PR TITLE
Fix for OS X build.

### DIFF
--- a/cblas/blas.go
+++ b/cblas/blas.go
@@ -12,7 +12,7 @@ package cblas
 #cgo linux LDFLAGS: -lcblas
 //#cgo linux LDFLAGS: -lmkl_rt
 //#cgo linux LDFLAGS: -L/path/to/OpenBLAS -lopenblas
-#cgo darwin LDFLAGS: -DYA_BLAS -DYA_LAPACK -DYA_BLASMULT -framework vecLib
+#cgo darwin LDFLAGS: -DYA_BLAS -DYA_LAPACK -DYA_BLASMULT -framework Accelerate
 //#cgo darwin LDFLAGS: -L/path/to/OpenBLAS -lopenblas
 #include "cblas.h"
 */

--- a/cblas/genBlas.pl
+++ b/cblas/genBlas.pl
@@ -51,7 +51,7 @@ package cblas
 /*
 #cgo CFLAGS: -g -O2
 #cgo linux LDFLAGS: -L/usr/lib/ -lcblas
-#cgo darwin LDFLAGS: -DYA_BLAS -DYA_LAPACK -DYA_BLASMULT -framework vecLib
+#cgo darwin LDFLAGS: -DYA_BLAS -DYA_LAPACK -DYA_BLASMULT -framework Accelerate
 #include "${cblasHeader}"
 */
 import "C"


### PR DESCRIPTION
Changed so that dependency is on the Accelerate framework, instead of
the deprecated vecLib framework. This caused `go install` to fail with the
following message on, at least, OS X Yosemite:

```
ld: framework not found vecLib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
