### PR TITLE
only calculate coverage when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,7 @@ script:
  - go build -x -v ./...
  - go test -x -v ./...
  - diff <(gofmt -d .) <("")
- - bash test-coverage.sh
- 
+ - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash test-coverage.sh; fi
 
 after_failure: failure
 


### PR DESCRIPTION
Travis-ci only makes secure environment variables available when
merging from a branch.  This change allows the test coverage to
continue to be calculated, even when merging from a fork.
