### PR TITLE
goblas: optimize Ddot using SSE2 on amd64

### DIFF
--- a/goblas/ddot.go
+++ b/goblas/ddot.go
@@ -1,4 +1,4 @@
-// Copyright ©2014 The gonum Authors. All rights reserved.
+// Copyright ©2015 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/goblas/ddot.go
+++ b/goblas/ddot.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // +build !amd64
 
 package goblas

--- a/goblas/ddot.go
+++ b/goblas/ddot.go
@@ -1,0 +1,19 @@
+// +build !amd64
+
+package goblas
+
+func ddotUnitary(x []float64, y []float64) (sum float64) {
+	for i, v := range x {
+		sum += y[i] * v
+	}
+	return
+}
+
+func ddotInc(x, y []float64, n, incX, incY, ix, iy uintptr) (sum float64) {
+	for i := 0; i < int(n); i++ {
+		sum += y[iy] * x[ix]
+		ix += incX
+		iy += incY
+	}
+	return
+}

--- a/goblas/ddot_amd64.go
+++ b/goblas/ddot_amd64.go
@@ -1,4 +1,4 @@
-// Copyright ©2014 The gonum Authors. All rights reserved.
+// Copyright ©2015 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/goblas/ddot_amd64.go
+++ b/goblas/ddot_amd64.go
@@ -1,0 +1,4 @@
+package goblas
+
+func ddotUnitary(x, y []float64) (sum float64)
+func ddotInc(x, y []float64, n, incX, incY, ix, iy uintptr) (sum float64)

--- a/goblas/ddot_amd64.go
+++ b/goblas/ddot_amd64.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package goblas
 
 func ddotUnitary(x, y []float64) (sum float64)

--- a/goblas/ddot_amd64.s
+++ b/goblas/ddot_amd64.s
@@ -1,0 +1,132 @@
+// Some of the loop unrolling code is copied from:
+// http://golang.org/src/math/big/arith_amd64.s
+// which is distributed under these terms:
+//
+// Copyright (c) 2012 The Go Authors. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// 
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+#include "textflag.h"
+
+// func ddotUnitary(x, y []float64) (sum float64)
+// This function assumes len(y) >= len(x).
+TEXT ·ddotUnitary(SB),NOSPLIT,$0
+	MOVQ x_len+8(FP), DI	// n = len(x)
+	MOVQ x+0(FP), R8
+	MOVQ y+24(FP), R9
+	
+	MOVQ $0, SI				// i = 0
+	MOVSD $(0.0), X7		// sum = 0
+	
+	SUBQ $2, DI				// n -= 2
+	JL V1					// if n < 0 goto V1
+
+U1:	// n >= 0
+	// sum += x[i] * y[i] unrolled 2x.
+	// We assume x and y are 16-byte aligned.
+	MOVAPD 0(R8)(SI*8), X0
+	MOVAPD 0(R9)(SI*8), X1
+	MULPD X1, X0
+	ADDPD X0, X7
+	
+	ADDQ $2, SI				// i += 2
+	SUBQ $2, DI				// n -= 2
+	JGE U1					// if n >= 0 goto U1
+
+V1:	// n > 0
+	ADDQ $2, DI				// n += 2
+	JLE E1					// if n <= 0 goto E1
+	
+	// sum += x[i] * y[i] for last iteration if n is odd.
+	MOVSD 0(R8)(SI*8), X0
+	MOVSD 0(R9)(SI*8), X1
+	MULSD X1, X0
+	ADDSD X0, X7
+
+E1:
+	// Add the two sums together.
+	MOVSD X7, X0
+	UNPCKHPD X7, X7
+	ADDSD X0, X7
+	MOVSD X7, sum+48(FP)	// return final sum
+	RET
+
+
+// func ddotInc(x, y []float64, n, incX, incY, ix, iy uintptr) (sum float64)
+TEXT ·ddotInc(SB),NOSPLIT,$0
+	MOVQ x+0(FP), R8
+	MOVQ y+24(FP), R9
+	MOVQ n+48(FP), CX
+	MOVQ incX+56(FP), R11
+	MOVQ incY+64(FP), R12
+	MOVQ ix+72(FP), R13
+	MOVQ iy+80(FP), R14
+	
+	MOVSD $(0.0), X7		// sum = 0
+	LEAQ (R8)(R13*8), SI	// p = &x[ix]
+	LEAQ (R9)(R14*8), DI	// q = &y[ix]
+	SHLQ $3, R11			// incX *= sizeof(float64)
+	SHLQ $3, R12			// indY *= sizeof(float64)
+	
+	SUBQ $2, CX				// n -= 2
+	JL V2					// if n < 0 goto V2
+
+U2:	// n >= 0
+	// sum += *p * *q unrolled 2x.
+	// x and y are 16-byte aligned, but we can't take advantage of it here.
+	MOVHPD (SI), X0
+	MOVHPD (DI), X1
+	ADDQ R11, SI			// p += incX
+	ADDQ R12, DI			// q += incY
+	MOVLPD (SI), X0
+	MOVLPD (DI), X1
+	ADDQ R11, SI			// p += incX
+	ADDQ R12, DI			// q += incY
+	
+	MULPD X1, X0
+	ADDPD X0, X7
+
+	SUBQ $2, CX				// n -= 2
+	JGE U2					// if n >= 0 goto U2
+
+V2:
+	ADDQ $2, CX				// n += 2
+	JLE E2					// if n <= 0 goto E2
+	
+	// sum += *p * *q for the last iteration if n is odd.
+	MOVSD (SI), X0
+	MULSD (DI), X0
+	ADDSD X0, X7
+
+E2:
+	// Add the two sums together.
+	MOVSD X7, X0
+	UNPCKHPD X7, X7
+	ADDSD X0, X7
+	MOVSD X7, sum+88(FP)	// return final sum
+	RET

--- a/goblas/ddot_amd64.s
+++ b/goblas/ddot_amd64.s
@@ -1,4 +1,4 @@
-// Copyright ©2014 The gonum Authors. All rights reserved.
+// Copyright ©2015 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //

--- a/goblas/ddot_amd64.s
+++ b/goblas/ddot_amd64.s
@@ -31,7 +31,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#include "textflag.h"
+// TODO(fhs): use textflag.h after we drop Go 1.3 support
+//#include "textflag.h"
+// Don't insert stack check preamble.
+#define NOSPLIT	4
+
 
 // func ddotUnitary(x, y []float64) (sum float64)
 // This function assumes len(y) >= len(x).

--- a/goblas/ddot_amd64.s
+++ b/goblas/ddot_amd64.s
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
 // Some of the loop unrolling code is copied from:
 // http://golang.org/src/math/big/arith_amd64.s
 // which is distributed under these terms:

--- a/goblas/level1double.go
+++ b/goblas/level1double.go
@@ -1,4 +1,4 @@
-// Copyright ©2014 The gonum Authors. All rights reserved.
+// Copyright ©2015 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/goblas/level1double.go
+++ b/goblas/level1double.go
@@ -1,3 +1,7 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // Uses the netlib standard. Other implementations may differ. Difference
 // is that the code panics for n < 0 and incx == 0 rather than returning zero.
 // (Documentation says incx must not be zero)

--- a/goblas/level1double.go
+++ b/goblas/level1double.go
@@ -21,6 +21,7 @@ const (
 	negativeN = "blas: negative number of elements"
 	zeroInc   = "blas: zero value of increment"
 	negInc    = "blas: negative value of increment"
+	badLen    = "blas: bad slice length"
 )
 
 /*
@@ -44,13 +45,11 @@ func (Blas) Ddot(n int, x []float64, incX int, y []float64, incY int) float64 {
 	if incX == 0 || incY == 0 {
 		panic(zeroInc)
 	}
-	var sum float64
 	if incX == 1 && incY == 1 {
-		x = x[:n]
-		for i, v := range x {
-			sum += y[i] * v
+		if len(x) < n || len(y) < n {
+			panic(badLen)
 		}
-		return sum
+		return ddotUnitary(x[:n], y)
 	}
 	var ix, iy int
 	if incX < 0 {
@@ -59,12 +58,10 @@ func (Blas) Ddot(n int, x []float64, incX int, y []float64, incY int) float64 {
 	if incY < 0 {
 		iy = (-n + 1) * incY
 	}
-	for i := 0; i < n; i++ {
-		sum += y[iy] * x[ix]
-		ix += incX
-		iy += incY
+	if ix >= len(x) || iy >= len(y) || ix+(n-1)*incX >= len(x) || iy+(n-1)*incY >= len(y) {
+		panic(badLen)
 	}
-	return sum
+	return ddotInc(x, y, uintptr(n), uintptr(incX), uintptr(incY), uintptr(ix), uintptr(iy))
 }
 
 // Dnrm2 computes the euclidean norm of a vector, sqrt(x'x).


### PR DESCRIPTION
Benchmark using Go 1.4 release on
Intel(R) Xeon(R) CPU E5-2660 0 @ 2.20GHz:

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkDdotSmallBothUnitary      18.5          14.9          -19.46%
BenchmarkDdotSmallIncUni           23.4          21.5          -8.12%
BenchmarkDdotSmallUniInc           23.4          22.2          -5.13%
BenchmarkDdotSmallBothInc          23.1          21.4          -7.36%
BenchmarkDdotMediumBothUnitary     1344          504           -62.50%
BenchmarkDdotMediumIncUni          1690          1187          -29.76%
BenchmarkDdotMediumUniInc          1686          1177          -30.19%
BenchmarkDdotMediumBothInc         1717          1210          -29.53%
BenchmarkDdotLargeBothUnitary      134869        59336         -56.00%
BenchmarkDdotLargeIncUni           223717        163716        -26.82%
BenchmarkDdotLargeUniInc           189230        141713        -25.11%
BenchmarkDdotLargeBothInc          242719        203594        -16.12%
BenchmarkDdotHugeBothUnitary       15563100      9585254       -38.41%
BenchmarkDdotHugeIncUni            34440563      31152669      -9.55%
BenchmarkDdotHugeUniInc            26460880      21385974      -19.18%
BenchmarkDdotHugeBothInc           40452938      40136997      -0.78%
```

On my laptop with Go 1.5-dev and Intel(R) Core(TM) i5-4330M CPU @ 2.80GHz I got these numbers
(they are actually not very stable because of CPU scaling):
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkDdotSmallBothUnitary      12.9          10.1          -21.71%
BenchmarkDdotSmallIncUni           16.5          16.1          -2.42%
BenchmarkDdotSmallUniInc           16.2          16.2          +0.00%
BenchmarkDdotSmallBothInc          16.2          16.0          -1.23%
BenchmarkDdotMediumBothUnitary     869           432           -50.29%
BenchmarkDdotMediumIncUni          1031          1021          -0.97%
BenchmarkDdotMediumUniInc          1027          1015          -1.17%
BenchmarkDdotMediumBothInc         1042          1022          -1.92%
BenchmarkDdotLargeBothUnitary      87156         44838         -48.55%
BenchmarkDdotLargeIncUni           230788        227383        -1.48%
BenchmarkDdotLargeUniInc           138736        129148        -6.91%
BenchmarkDdotLargeBothInc          335562        333651        -0.57%
BenchmarkDdotHugeBothUnitary       11050482      8906654       -19.40%
BenchmarkDdotHugeIncUni            28042141      27658908      -1.37%
BenchmarkDdotHugeUniInc            19012855      17787912      -6.44%
BenchmarkDdotHugeBothInc           34613451      34130483      -1.40%
```
I would be interested in what numbers other people get! Run:
```
go test -bench BenchmarkDdot  > old.txt
go test -bench BenchmarkDdot  > new.txt
go get golang.org/x/tools/cmd/benchcmp
benchcmp old.txt new.txt
```
