### PR TITLE
goblas: fix Ddot for unaligned slices

### DIFF
--- a/goblas/ddot_amd64.s
+++ b/goblas/ddot_amd64.s
@@ -56,9 +56,8 @@ TEXT ·ddotUnitary(SB),NOSPLIT,$0
 
 U1:	// n >= 0
 	// sum += x[i] * y[i] unrolled 2x.
-	// We assume x and y are 16-byte aligned.
-	MOVAPD 0(R8)(SI*8), X0
-	MOVAPD 0(R9)(SI*8), X1
+	MOVUPD 0(R8)(SI*8), X0
+	MOVUPD 0(R9)(SI*8), X1
 	MULPD X1, X0
 	ADDPD X0, X7
 	
@@ -106,7 +105,6 @@ TEXT ·ddotInc(SB),NOSPLIT,$0
 
 U2:	// n >= 0
 	// sum += *p * *q unrolled 2x.
-	// x and y are 16-byte aligned, but we can't take advantage of it here.
 	MOVHPD (SI), X0
 	MOVHPD (DI), X1
 	ADDQ R11, SI			// p += incX

--- a/testblas/level1double.go
+++ b/testblas/level1double.go
@@ -1086,6 +1086,12 @@ func DdotTest(t *testing.T, d Ddotter) {
 			t.Errorf("ddot: mismatch %v: expected %v, found %v", c.Name, c.DdotAns, dot)
 		}
 	}
+
+	// check it works for 16-byte unaligned slices
+	x := []float64{1, 1, 1, 1, 1}
+	if n := ddot(4, x[:4], 1, x[1:], 1); n != 4 {
+		t.Errorf("ddot: mismatch Unaligned: expected %v, found %v", 4, n)
+	}
 }
 
 type Dnrm2er interface {


### PR DESCRIPTION
No real change in the benchmark results
(Go 1.4 on Intel(R) Xeon(R) CPU E5-2660 0 @ 2.20GHz):
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkDdotSmallBothUnitary      15.3          15.3          +0.00%
BenchmarkDdotSmallIncUni           21.5          21.5          +0.00%
BenchmarkDdotSmallUniInc           22.0          22.0          +0.00%
BenchmarkDdotSmallBothInc          21.5          21.5          +0.00%
BenchmarkDdotMediumBothUnitary     505           505           +0.00%
BenchmarkDdotMediumIncUni          1186          1188          +0.17%
BenchmarkDdotMediumUniInc          1178          1178          +0.00%
BenchmarkDdotMediumBothInc         1220          1213          -0.57%
BenchmarkDdotLargeBothUnitary      59322         59327         +0.01%
BenchmarkDdotLargeIncUni           163780        163693        -0.05%
BenchmarkDdotLargeUniInc           141651        141706        +0.04%
BenchmarkDdotLargeBothInc          203541        203794        +0.12%
BenchmarkDdotHugeBothUnitary       9586039       9586340       +0.00%
BenchmarkDdotHugeIncUni            31228460      31128999      -0.32%
BenchmarkDdotHugeUniInc            21437424      21476630      +0.18%
BenchmarkDdotHugeBothInc           40115032      40122703      +0.02%
```
Fixes #77