### PR TITLE
goblas: optimize Daxpy using SSE2 on amd64

### DIFF
--- a/goblas/daxpy.go
+++ b/goblas/daxpy.go
@@ -1,0 +1,21 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !amd64
+
+package goblas
+
+func daxpyUnitary(alpha float64, x, y []float64) {
+	for i, v := range x {
+		y[i] += alpha * v
+	}
+}
+
+func daxpyInc(alpha float64, x, y []float64, n, incX, incY, ix, iy uintptr) {
+	for i := 0; i < int(n); i++ {
+		y[iy] += alpha * x[ix]
+		ix += incX
+		iy += incY
+	}
+}

--- a/goblas/daxpy_amd64.go
+++ b/goblas/daxpy_amd64.go
@@ -1,0 +1,8 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package goblas
+
+func daxpyUnitary(alpha float64, x, y []float64)
+func daxpyInc(alpha float64, x, y []float64, n, incX, incY, ix, iy uintptr)

--- a/goblas/daxpy_amd64.s
+++ b/goblas/daxpy_amd64.s
@@ -1,0 +1,138 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// Some of the loop unrolling code is copied from:
+// http://golang.org/src/math/big/arith_amd64.s
+// which is distributed under these terms:
+//
+// Copyright (c) 2012 The Go Authors. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// 
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+// TODO(fhs): use textflag.h after we drop Go 1.3 support
+//#include "textflag.h"
+// Don't insert stack check preamble.
+#define NOSPLIT	4
+
+
+// func daxpyUnitary(alpha float64, x, y []float64)
+// This function assumes len(y) >= len(x).
+TEXT ·daxpyUnitary(SB),NOSPLIT,$0
+	MOVHPD alpha+0(FP), X7
+	MOVLPD alpha+0(FP), X7
+	MOVQ x_len+16(FP), DI	// n = len(x)
+	MOVQ x+8(FP), R8
+	MOVQ y+32(FP), R9
+	
+	MOVQ $0, SI				// i = 0
+	SUBQ $2, DI				// n -= 2
+	JL V1					// if n < 0 goto V1
+
+U1:	// n >= 0
+	// y[i] += alpha * x[i] unrolled 2x.
+	MOVUPD 0(R8)(SI*8), X0
+	MOVUPD 0(R9)(SI*8), X1
+	MULPD X7, X0
+	ADDPD X0, X1
+	MOVUPD X1, 0(R9)(SI*8)
+	
+	ADDQ $2, SI				// i += 2
+	SUBQ $2, DI				// n -= 2
+	JGE U1					// if n >= 0 goto U1
+
+V1:
+	ADDQ $2, DI				// n += 2
+	JLE E1					// if n <= 0 goto E1
+	
+	// y[i] += alpha * x[i] for last iteration if n is odd.
+	MOVSD 0(R8)(SI*8), X0
+	MOVSD 0(R9)(SI*8), X1
+	MULSD X7, X0
+	ADDSD X0, X1
+	MOVSD X1, 0(R9)(SI*8)
+
+E1:
+	RET
+
+
+// func daxpyInc(alpha float64, x, y []float64, n, incX, incY, ix, iy uintptr)
+TEXT ·daxpyInc(SB),NOSPLIT,$0
+	MOVHPD alpha+0(FP), X7
+	MOVLPD alpha+0(FP), X7
+	MOVQ x+8(FP), R8
+	MOVQ y+32(FP), R9
+	MOVQ n+56(FP), CX
+	MOVQ incX+64(FP), R11
+	MOVQ incY+72(FP), R12
+	MOVQ ix+80(FP), SI
+	MOVQ iy+88(FP), DI
+
+	MOVQ SI, AX				// nextX = ix
+	MOVQ DI, BX				// nextY = iy
+	ADDQ R11, AX			// nextX += incX
+	ADDQ R12, BX			// nextY += incX
+	SHLQ $1, R11			// indX *= 2
+	SHLQ $1, R12			// indY *= 2
+	
+	SUBQ $2, CX				// n -= 2
+	JL V2					// if n < 0 goto V2
+
+U2:	// n >= 0
+	// y[i] += alpha * x[i] unrolled 2x.
+	MOVHPD 0(R8)(SI*8), X0
+	MOVHPD 0(R9)(DI*8), X1
+	MOVLPD 0(R8)(AX*8), X0
+	MOVLPD 0(R9)(BX*8), X1
+	
+	MULPD X7, X0
+	ADDPD X0, X1
+	MOVHPD X1, 0(R9)(DI*8)
+	MOVLPD X1, 0(R9)(BX*8)
+
+	ADDQ R11, SI			// ix += incX
+	ADDQ R12, DI			// iy += incY
+	ADDQ R11, AX			// nextX += incX
+	ADDQ R12, BX			// nextY += incY
+
+	SUBQ $2, CX				// n -= 2
+	JGE U2					// if n >= 0 goto U2
+
+V2:
+	ADDQ $2, CX				// n += 2
+	JLE E2					// if n <= 0 goto E2
+	
+	// y[i] += alpha * x[i] for the last iteration if n is odd.
+	MOVSD 0(R8)(SI*8), X0
+	MOVSD 0(R9)(DI*8), X1
+	MULSD X7, X0
+	ADDSD X0, X1
+	MOVSD X1, 0(R9)(DI*8)
+
+E2:
+	RET

--- a/goblas/level1double.go
+++ b/goblas/level1double.go
@@ -269,10 +269,10 @@ func (Blas) Daxpy(n int, alpha float64, x []float64, incX int, y []float64, incY
 		return
 	}
 	if incX == 1 && incY == 1 {
-		x = x[:n]
-		for i, v := range x {
-			y[i] += alpha * v
+		if len(x) < n || len(y) < n {
+			panic(badLen)
 		}
+		daxpyUnitary(alpha, x[:n], y)
 		return
 	}
 	var ix, iy int
@@ -282,11 +282,10 @@ func (Blas) Daxpy(n int, alpha float64, x []float64, incX int, y []float64, incY
 	if incY < 0 {
 		iy = (-n + 1) * incY
 	}
-	for i := 0; i < n; i++ {
-		y[iy] += alpha * x[ix]
-		ix += incX
-		iy += incY
+	if ix >= len(x) || iy >= len(y) || ix+(n-1)*incX >= len(x) || iy+(n-1)*incY >= len(y) {
+		panic(badLen)
 	}
+	daxpyInc(alpha, x, y, uintptr(n), uintptr(incX), uintptr(incY), uintptr(ix), uintptr(iy))
 }
 
 // Drotg gives plane rotation


### PR DESCRIPTION
Go 1.4 on Intel(R) Xeon(R) CPU E5-2660 0 @ 2.20GHz:
```
benchmark                           old ns/op     new ns/op     delta
BenchmarkDaxpySmallBothUnitary      22.4          15.4          -31.25%
BenchmarkDaxpySmallIncUni           24.4          24.2          -0.82%
BenchmarkDaxpySmallUniInc           24.6          24.1          -2.03%
BenchmarkDaxpySmallBothInc          24.4          23.5          -3.69%
BenchmarkDaxpyMediumBothUnitary     1351          360           -73.35%
BenchmarkDaxpyMediumIncUni          1695          1226          -27.67%
BenchmarkDaxpyMediumUniInc          1586          1185          -25.28%
BenchmarkDaxpyMediumBothInc         1733          1357          -21.70%
BenchmarkDaxpyLargeBothUnitary      136000        72131         -46.96%
BenchmarkDaxpyLargeIncUni           240527        198011        -17.68%
BenchmarkDaxpyLargeUniInc           206700        162471        -21.40%
BenchmarkDaxpyLargeBothInc          279814        239500        -14.41%
BenchmarkDaxpyHugeBothUnitary       16175068      12855609      -20.52%
BenchmarkDaxpyHugeIncUni            37333482      34263411      -8.22%
BenchmarkDaxpyHugeUniInc            29515256      27305122      -7.49%
BenchmarkDaxpyHugeBothInc           47188205      47970088      +1.66%
```