### PR TITLE
testblas: test Level 1 single precision

### DIFF
--- a/native/internal/math32/math.go
+++ b/native/internal/math32/math.go
@@ -23,6 +23,11 @@ const (
 	bias    = 127
 )
 
+// Mathematical constants.
+const (
+	Pi = math.Pi
+)
+
 // Abs returns the absolute value of x.
 //
 // Special cases are:
@@ -111,3 +116,33 @@ func IsNaN(f float32) (is bool) {
 
 // NaN returns an IEEE 754 ``not-a-number'' value.
 func NaN() float32 { return math.Float32frombits(unan) }
+
+// Cos returns the cosine of the radian argument x.
+//
+// Special cases are:
+//	Cos(±Inf) = NaN
+//	Cos(NaN) = NaN
+func Cos(x float32) float32 {
+	return float32(math.Cos(float64(x)))
+}
+
+// Sin returns the sine of the radian argument x.
+//
+// Special cases are:
+//	Sin(±0) = ±0
+//	Sin(±Inf) = NaN
+//	Sin(NaN) = NaN
+func Sin(x float32) float32 {
+	return float32(math.Sin(float64(x)))
+}
+
+// Max returns the larger of x or y.
+//
+// Special cases are:
+//	Max(x, +Inf) = Max(+Inf, x) = +Inf
+//	Max(x, NaN) = Max(NaN, x) = NaN
+//	Max(+0, ±0) = Max(±0, +0) = +0
+//	Max(-0, -0) = -0
+func Max(x, y float32) float32 {
+	return float32(math.Max(float64(x), float64(y)))
+}

--- a/native/level1single_test.go
+++ b/native/level1single_test.go
@@ -1,0 +1,59 @@
+// Copyright ©2014 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package native
+
+import (
+	"testing"
+
+	testblas "github.com/gonum/blas/testblas/single"
+)
+
+func TestSasum(t *testing.T) {
+	testblas.DasumTest(t, impl)
+}
+
+func TestSaxpy(t *testing.T) {
+	testblas.DaxpyTest(t, impl)
+}
+
+func TestSdot(t *testing.T) {
+	testblas.DdotTest(t, impl)
+}
+
+func TestSnrm2(t *testing.T) {
+	testblas.Dnrm2Test(t, impl)
+}
+
+func TestIsamax(t *testing.T) {
+	testblas.IdamaxTest(t, impl)
+}
+
+func TestSswap(t *testing.T) {
+	testblas.DswapTest(t, impl)
+}
+
+func TestScopy(t *testing.T) {
+	testblas.DcopyTest(t, impl)
+}
+
+func TestSrotg(t *testing.T) {
+	testblas.DrotgTest(t, impl)
+}
+
+func TestSrotmg(t *testing.T) {
+	testblas.DrotmgTest(t, impl)
+}
+
+func TestSrot(t *testing.T) {
+	testblas.DrotTest(t, impl)
+}
+
+func TestSrotm(t *testing.T) {
+	testblas.DrotmTest(t, impl)
+}
+
+func TestSscal(t *testing.T) {
+	testblas.DscalTest(t, impl)
+}

--- a/native/single_precision
+++ b/native/single_precision
@@ -137,3 +137,13 @@ cat dgemm.go \
       -e 's_^// D_// S_' \
       -e 's_^// d_// s_' \
 >> sgemm.go
+
+
+echo Generating level1single_test.go
+cat level1double_test.go \
+| sed 's_"github.com/gonum/blas/testblas"_testblas "github.com/gonum/blas/testblas/single"_' \
+| sed '/^var impl/d' \
+| sed 's/^\(func Test\)D/\1S/' \
+| gofmt -r 'TestIdamax -> TestIsamax' \
+| goimports \
+> level1single_test.go

--- a/testblas/single/common.go
+++ b/testblas/single/common.go
@@ -1,8 +1,9 @@
-package testblas
+package single
 
 import (
-	"math"
 	"testing"
+
+	math "github.com/gonum/blas/native/internal/math32"
 
 	"github.com/gonum/blas"
 )
@@ -10,7 +11,7 @@ import (
 // throwPanic will throw unexpected panics if true, or will just report them as errors if false
 const throwPanic = true
 
-func dTolEqual(a, b float64) bool {
+func dTolEqual(a, b float32) bool {
 	if math.IsNaN(a) && math.IsNaN(b) {
 		return true
 	}
@@ -19,13 +20,13 @@ func dTolEqual(a, b float64) bool {
 		a /= m
 		b /= m
 	}
-	if math.Abs(a-b) < 1e-14 {
+	if math.Abs(a-b) < 1e-6 {
 		return true
 	}
 	return false
 }
 
-func dSliceTolEqual(a, b []float64) bool {
+func dSliceTolEqual(a, b []float32) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -37,7 +38,7 @@ func dSliceTolEqual(a, b []float64) bool {
 	return true
 }
 
-func dStridedSliceTolEqual(n int, a []float64, inca int, b []float64, incb int) bool {
+func dStridedSliceTolEqual(n int, a []float32, inca int, b []float32, incb int) bool {
 	ia := 0
 	ib := 0
 	if inca <= 0 {
@@ -56,7 +57,7 @@ func dStridedSliceTolEqual(n int, a []float64, inca int, b []float64, incb int) 
 	return true
 }
 
-func dSliceEqual(a, b []float64) bool {
+func dSliceEqual(a, b []float32) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -68,7 +69,7 @@ func dSliceEqual(a, b []float64) bool {
 	return true
 }
 
-func dCopyTwoTmp(x, xTmp, y, yTmp []float64) {
+func dCopyTwoTmp(x, xTmp, y, yTmp []float32) {
 	if len(x) != len(xTmp) {
 		panic("x size mismatch")
 	}
@@ -102,28 +103,28 @@ func testpanics(f func(), name string, t *testing.T) {
 	}
 }
 
-func sliceOfSliceCopy(a [][]float64) [][]float64 {
-	n := make([][]float64, len(a))
+func sliceOfSliceCopy(a [][]float32) [][]float32 {
+	n := make([][]float32, len(a))
 	for i := range a {
-		n[i] = make([]float64, len(a[i]))
+		n[i] = make([]float32, len(a[i]))
 		copy(n[i], a[i])
 	}
 	return n
 }
 
-func sliceCopy(a []float64) []float64 {
-	n := make([]float64, len(a))
+func sliceCopy(a []float32) []float32 {
+	n := make([]float32, len(a))
 	copy(n, a)
 	return n
 }
 
-func flatten(a [][]float64) []float64 {
+func flatten(a [][]float32) []float32 {
 	if len(a) == 0 {
 		return nil
 	}
 	m := len(a)
 	n := len(a[0])
-	s := make([]float64, m*n)
+	s := make([]float32, m*n)
 	for i := 0; i < m; i++ {
 		for j := 0; j < n; j++ {
 			s[i*n+j] = a[i][j]
@@ -132,10 +133,10 @@ func flatten(a [][]float64) []float64 {
 	return s
 }
 
-func unflatten(a []float64, m, n int) [][]float64 {
-	s := make([][]float64, m)
+func unflatten(a []float32, m, n int) [][]float32 {
+	s := make([][]float32, m)
 	for i := 0; i < m; i++ {
-		s[i] = make([]float64, n)
+		s[i] = make([]float32, n)
 		for j := 0; j < n; j++ {
 			s[i][j] = a[i*n+j]
 		}
@@ -145,9 +146,9 @@ func unflatten(a []float64, m, n int) [][]float64 {
 
 // flattenTriangular turns the upper or lower triangle of a dense slice of slice
 // into a single slice with packed storage. a must be a square matrix.
-func flattenTriangular(a [][]float64, ul blas.Uplo) []float64 {
+func flattenTriangular(a [][]float32, ul blas.Uplo) []float32 {
 	m := len(a)
-	aFlat := make([]float64, m*(m+1)/2)
+	aFlat := make([]float32, m*(m+1)/2)
 	var k int
 	if ul == blas.Upper {
 		for i := 0; i < m; i++ {
@@ -162,7 +163,7 @@ func flattenTriangular(a [][]float64, ul blas.Uplo) []float64 {
 }
 
 // flattenBanded turns a dense banded slice of slice into the compact banded matrix format
-func flattenBanded(a [][]float64, ku, kl int) []float64 {
+func flattenBanded(a [][]float32, ku, kl int) []float32 {
 	m := len(a)
 	n := len(a[0])
 	if ku < 0 || kl < 0 {
@@ -170,7 +171,7 @@ func flattenBanded(a [][]float64, ku, kl int) []float64 {
 	}
 	nRows := m
 	nCols := (ku + kl + 1)
-	aflat := make([]float64, nRows*nCols)
+	aflat := make([]float32, nRows*nCols)
 	for i := range aflat {
 		aflat[i] = math.NaN()
 	}
@@ -196,7 +197,7 @@ func flattenBanded(a [][]float64, ku, kl int) []float64 {
 
 // makeIncremented takes a slice with inc == 1 and makes an incremented version
 // and adds extra values on the end
-func makeIncremented(x []float64, inc int, extra int) []float64 {
+func makeIncremented(x []float32, inc int, extra int) []float32 {
 	if inc == 0 {
 		panic("zero inc")
 	}
@@ -204,7 +205,7 @@ func makeIncremented(x []float64, inc int, extra int) []float64 {
 	if absinc < 0 {
 		absinc = -inc
 	}
-	xcopy := make([]float64, len(x))
+	xcopy := make([]float32, len(x))
 	if inc > 0 {
 		copy(xcopy, x)
 	} else {
@@ -215,8 +216,8 @@ func makeIncremented(x []float64, inc int, extra int) []float64 {
 
 	// don't use NaN because it makes comparison hard
 	// Do use a weird unique value for easier debugging
-	counter := float64(100.0)
-	var xnew []float64
+	counter := float32(100.0)
+	var xnew []float32
 	for i, v := range xcopy {
 		xnew = append(xnew, v)
 		if i != len(x)-1 {

--- a/testblas/single/generate.sh
+++ b/testblas/single/generate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright ©2015 The gonum Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+echo Generating level1.go
+cat ../level1double.go |
+	gofmt -r 'float64 -> float32' |
+	gofmt -r 'DrotmParams -> SrotmParams' |
+	gofmt -r 'Dasum -> Sasum' |
+	gofmt -r 'Daxpy -> Saxpy' |
+	gofmt -r 'Ddot -> Sdot' |
+	gofmt -r 'Dnrm2 -> Snrm2' |
+	gofmt -r 'Idamax -> Isamax' |
+	gofmt -r 'Dswap -> Sswap' |
+	gofmt -r 'Dcopy -> Scopy' |
+	gofmt -r 'Drotg -> Srotg' |
+	gofmt -r 'Drotmg -> Srotmg' |
+	gofmt -r 'Drot -> Srot' |
+	gofmt -r 'Drotm -> Srotm' |
+	gofmt -r 'Dscal -> Sscal' |
+	sed -e 's_"math"_math "github.com/gonum/blas/native/internal/math32"_' |
+	gofmt -r 'testblas -> single' |
+	goimports > level1.go
+
+echo Generating common.go
+cat ../common.go |
+	gofmt -r 'float64 -> float32' |
+	gofmt -r '1e-14 -> 1e-6' |
+	sed -e 's_"math"_math "github.com/gonum/blas/native/internal/math32"_' |
+	gofmt -r 'testblas -> single' |
+	goimports > common.go

--- a/testblas/single/level1.go
+++ b/testblas/single/level1.go
@@ -1,0 +1,1765 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package testblas provides tests for blas implementions.
+package single
+
+import (
+	"github.com/gonum/blas"
+
+	"testing"
+
+	math "github.com/gonum/blas/native/internal/math32"
+)
+
+type DoubleOneVectorCase struct {
+	Name       string
+	X          []float32
+	Incx       int
+	N          int
+	Panic      bool
+	Sasum      float32
+	Snrm2      float32
+	Isamax     int
+	DscalCases []DScalCase
+}
+
+type DScalCase struct {
+	Alpha float32
+	Ans   []float32
+	Name  string
+}
+
+var DoubleOneVectorCases = []DoubleOneVectorCase{
+	{
+		Name:   "AllPositive",
+		X:      []float32{6, 5, 4, 2, 6},
+		Incx:   1,
+		N:      5,
+		Panic:  false,
+		Sasum:  23,
+		Snrm2:  10.81665382639196787935766380241148783875388972153573863813135,
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: 0,
+				Ans:   []float32{0, 0, 0, 0, 0},
+			},
+			{
+				Alpha: 1,
+				Ans:   []float32{6, 5, 4, 2, 6},
+			},
+			{
+				Alpha: -2,
+				Ans:   []float32{-12, -10, -8, -4, -12},
+			},
+		},
+	},
+	{
+		Name:   "MaxInMiddle",
+		X:      []float32{6, 5, 9, 0, 6},
+		Incx:   1,
+		N:      5,
+		Panic:  false,
+		Sasum:  26,
+		Snrm2:  13.34166406412633371248943627250846646911846482744007727141318,
+		Isamax: 2,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-12, -10, -18, 0, -12},
+			},
+		},
+	},
+	{
+		Name:   "MaxAtEnd",
+		X:      []float32{6, 5, -9, 0, 10},
+		Incx:   1,
+		N:      5,
+		Panic:  false,
+		Sasum:  30,
+		Snrm2:  15.55634918610404553681857596630667886426639062914642880494347,
+		Isamax: 4,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-12, -10, 18, 0, -20},
+			},
+		},
+	},
+	{
+		Name:   "AllNegative",
+		X:      []float32{-6, -5, -4, -2, -6},
+		Incx:   1,
+		N:      5,
+		Panic:  false,
+		Sasum:  23,
+		Snrm2:  10.81665382639196787935766380241148783875388972153573863813135,
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{12, 10, 8, 4, 12},
+			},
+		},
+	},
+	{
+		Name:   "AllMixed",
+		X:      []float32{-6, 5, 4, -2, -6},
+		Incx:   1,
+		N:      5,
+		Panic:  false,
+		Sasum:  23,
+		Snrm2:  10.81665382639196787935766380241148783875388972153573863813135,
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{12, -10, -8, 4, 12},
+			},
+		},
+	},
+	{
+		Name:   "ZeroN",
+		X:      []float32{-6, 5, 4, -2, -6},
+		Incx:   1,
+		N:      0,
+		Panic:  false,
+		Sasum:  0,
+		Snrm2:  0,
+		Isamax: -1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:   "OneN",
+		X:      []float32{-6, 5, 4, -2, -6},
+		Incx:   1,
+		N:      1,
+		Panic:  false,
+		Sasum:  6,
+		Snrm2:  6,
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{12, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:   "PositiveExactInc",
+		X:      []float32{-6, 5, 10, -2, -5},
+		Incx:   2,
+		N:      3,
+		Panic:  false,
+		Sasum:  21,
+		Snrm2:  12.68857754044952038019377274608948979173952662752515253090272,
+		Isamax: 1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{12, 5, -20, -2, 10},
+			},
+		},
+	},
+	{
+		Name:   "PositiveOffInc",
+		X:      []float32{-6, 5, 4, -2, -6, 8, 10, 11},
+		Incx:   3,
+		N:      3,
+		Panic:  false,
+		Sasum:  18,
+		Snrm2:  11.83215956619923208513465658312323409683100246158868064575943,
+		Isamax: 2,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{12, 5, 4, 4, -6, 8, -20, 11},
+			},
+		},
+	},
+	{
+		Name:   "PositiveShortInc",
+		X:      []float32{-6, 5, 4, -2, -6, 8, 10, 11},
+		Incx:   3,
+		N:      2,
+		Panic:  false,
+		Sasum:  8,
+		Snrm2:  6.324555320336758663997787088865437067439110278650433653715009,
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{12, 5, 4, 4, -6, 8, 10, 11},
+			},
+		},
+	},
+	{
+		Name:   "NegativeInc",
+		X:      []float32{-6, 5, 4, -2, -6},
+		Incx:   -1,
+		N:      5,
+		Panic:  false,
+		Sasum:  0,
+		Snrm2:  0,
+		Isamax: -1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:   "NegativeExactInc",
+		X:      []float32{-6, 5, 4, -2, -6},
+		Incx:   -2,
+		N:      3,
+		Panic:  false,
+		Sasum:  0,
+		Snrm2:  0,
+		Isamax: -1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:   "NegativeOffInc",
+		X:      []float32{-6, 5, 4, -2, -6, 8, 10, 11},
+		Incx:   -3,
+		N:      2,
+		Panic:  false,
+		Sasum:  0,
+		Snrm2:  0,
+		Isamax: -1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6, 8, 10, 11},
+			},
+		},
+	},
+	{
+		Name:   "NegativeShortInc",
+		X:      []float32{-6, 5, 4, -2, -6, 8, 10, 11},
+		Incx:   -3,
+		N:      2,
+		Panic:  false,
+		Sasum:  0,
+		Snrm2:  0,
+		Isamax: -1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6, 8, 10, 11},
+			},
+		},
+	},
+	{
+		Name:  "NegativeN",
+		X:     []float32{-6, 5, 4, -2, -6},
+		Incx:  2,
+		N:     -5,
+		Panic: true,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:  "ZeroInc",
+		X:     []float32{-6, 5, 4, -2, -6},
+		Incx:  0,
+		N:     5,
+		Panic: true,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:  "OutOfBounds",
+		X:     []float32{-6, 5, 4, -2, -6},
+		Incx:  2,
+		N:     6,
+		Panic: true,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:   "NegativeOutOfBounds",
+		X:      []float32{-6, 5, 4, -2, -6},
+		Incx:   -2,
+		N:      6,
+		Panic:  false,
+		Sasum:  0,
+		Snrm2:  0,
+		Isamax: -1,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{-6, 5, 4, -2, -6},
+			},
+		},
+	},
+	{
+		Name:   "NaN",
+		X:      []float32{math.NaN(), 2.0},
+		Incx:   1,
+		N:      2,
+		Panic:  false,
+		Sasum:  math.NaN(),
+		Snrm2:  math.NaN(),
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{math.NaN(), -4.0},
+			},
+			{
+				Alpha: 0,
+				Ans:   []float32{0, 0},
+			},
+		},
+	},
+	{
+		Name:   "NaNInc",
+		X:      []float32{math.NaN(), math.NaN(), 2.0},
+		Incx:   2,
+		N:      2,
+		Panic:  false,
+		Sasum:  math.NaN(),
+		Snrm2:  math.NaN(),
+		Isamax: 0,
+		DscalCases: []DScalCase{
+			{
+				Alpha: -2,
+				Ans:   []float32{math.NaN(), math.NaN(), -4.0},
+			},
+			{
+				Alpha: 0,
+				Ans:   []float32{0, math.NaN(), 0},
+			},
+		},
+	},
+}
+
+type DoubleTwoVectorCase struct {
+	Name  string
+	X     []float32
+	Y     []float32
+	XTmp  []float32
+	YTmp  []float32
+	Incx  int
+	Incy  int
+	N     int
+	Panic bool
+	// For Daxpy
+	DaxpyCases []DaxpyCase
+	DdotAns    float32
+	DswapAns   DTwoVecAnswer
+	DcopyAns   DTwoVecAnswer
+	DrotCases  []DrotCase
+	DrotmCases []DrotmCase
+}
+
+type DaxpyCase struct {
+	Alpha float32
+	Ans   []float32
+}
+
+type DrotCase struct {
+	C    float32
+	S    float32
+	XAns []float32
+	YAns []float32
+}
+
+type DrotmCase struct {
+	P    blas.SrotmParams
+	XAns []float32
+	YAns []float32
+	Name string
+}
+
+type DTwoVecAnswer struct {
+	X []float32
+	Y []float32
+}
+
+var DoubleTwoVectorCases = []DoubleTwoVectorCase{
+	{
+		Name:  "UnitaryInc",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0},
+		Incx:  1,
+		Incy:  1,
+		N:     6,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 1,
+				Ans:   []float32{18, 13, -2, 10, 20, 4},
+			},
+			{
+				Alpha: 2,
+				Ans:   []float32{28, 28, -8, 13, 34, 11},
+			},
+			{
+				Alpha: -3,
+				Ans:   []float32{-22, -47, 22, -2, -36, -24},
+			},
+			{
+				Alpha: 0,
+				Ans:   []float32{8, -2, 4, 7, 6, -3},
+			},
+		},
+		DdotAns: 110,
+		DswapAns: DTwoVecAnswer{
+			X: []float32{8, -2, 4, 7, 6, -3},
+			Y: []float32{10, 15, -6, 3, 14, 7},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{10, 15, -6, 3, 14, 7},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(0),
+				S:    math.Sin(0),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3},
+			},
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{12.444023964292095, 12.749380282068351, -3.7473736752571014, 5.677251193294846, 15.224018588957296, 5.076299724034451},
+				YAns: []float32{3.024279678886205, -8.151889500183792, 6.160940718590796, 5.076299724034451, -0.4788089421498931, -5.677251193294846},
+			},
+			{
+				C:    math.Cos(0.5 * math.Pi),
+				S:    math.Sin(0.5 * math.Pi),
+				XAns: []float32{8, -2, 4, 7, 6, -3},
+				YAns: []float32{-10, -15, 6, -3, -14, -7},
+			},
+			{
+				C:    math.Cos(math.Pi),
+				S:    math.Sin(math.Pi),
+				XAns: []float32{-10, -15, 6, -3, -14, -7},
+				YAns: []float32{-8, 2, -4, -7, -6, 3},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Identity,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3},
+				Name: "Neg2Flag",
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 13.7, -5.8, 2, 12, 6.6},
+				YAns: []float32{5, 0.5, 1.4, 3.8, 4.4, -0.8},
+				Name: "Neg1Flag",
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.OffDiagonal,
+					H:    [4]float32{1, 0.1, -0.1, 1},
+				},
+				XAns: []float32{9.2, 15.2, -6.4, 2.3, 13.4, 7.3},
+				YAns: []float32{9, -0.5, 3.4, 7.3, 7.4, -2.3},
+				Name: "ZeroFlag",
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Diagonal,
+					H:    [4]float32{0.5, -1, 1, 0.7},
+				},
+				XAns: []float32{13, 5.5, 1, 8.5, 13, 0.5},
+				YAns: []float32{-4.4, -16.4, 8.8, 1.9, -9.8, -9.1},
+				Name: "OneFlag",
+			},
+		},
+	},
+	{
+		Name:  "UnitaryIncLong",
+		X:     []float32{10, 15, -6, 3, 14, 7, 8, -9, 10},
+		Y:     []float32{8, -2, 4, 7, 6, -3, 7, -6},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  1,
+		Incy:  1,
+		N:     6,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 1,
+				Ans:   []float32{18, 13, -2, 10, 20, 4, 7, -6},
+			},
+			{
+				Alpha: 2,
+				Ans:   []float32{28, 28, -8, 13, 34, 11, 7, -6},
+			},
+			{
+				Alpha: -3,
+				Ans:   []float32{-22, -47, 22, -2, -36, -24, 7, -6},
+			},
+			{
+				Alpha: 0,
+				Ans:   []float32{8, -2, 4, 7, 6, -3, 7, -6},
+			},
+		},
+		DdotAns: 110,
+		DswapAns: DTwoVecAnswer{
+			X: []float32{8, -2, 4, 7, 6, -3, 8, -9, 10},
+			Y: []float32{10, 15, -6, 3, 14, 7, 7, -6},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7, 8, -9, 10},
+			Y: []float32{10, 15, -6, 3, 14, 7, 7, -6},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(0),
+				S:    math.Sin(0),
+				XAns: []float32{10, 15, -6, 3, 14, 7, 8, -9, 10},
+				YAns: []float32{8, -2, 4, 7, 6, -3, 7, -6},
+			},
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{12.444023964292095, 12.749380282068351, -3.7473736752571014, 5.677251193294846, 15.224018588957296, 5.076299724034451, 8, -9, 10},
+				YAns: []float32{3.024279678886205, -8.151889500183792, 6.160940718590796, 5.076299724034451, -0.4788089421498931, -5.677251193294846, 7, -6},
+			},
+			{
+				C:    math.Cos(0.5 * math.Pi),
+				S:    math.Sin(0.5 * math.Pi),
+				XAns: []float32{8, -2, 4, 7, 6, -3, 8, -9, 10},
+				YAns: []float32{-10, -15, 6, -3, -14, -7, 7, -6},
+			},
+			{
+				C:    math.Cos(math.Pi),
+				S:    math.Sin(math.Pi),
+				XAns: []float32{-10, -15, 6, -3, -14, -7, 8, -9, 10},
+				YAns: []float32{-8, 2, -4, -7, -6, 3, 7, -6},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Identity,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{10, 15, -6, 3, 14, 7, 8, -9, 10},
+				YAns: []float32{8, -2, 4, 7, 6, -3, 7, -6},
+				Name: "Neg2Flag",
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 13.7, -5.8, 2, 12, 6.6, 8, -9, 10},
+				YAns: []float32{5, 0.5, 1.4, 3.8, 4.4, -0.8, 7, -6},
+				Name: "Neg1Flag",
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.OffDiagonal,
+					H:    [4]float32{1, 0.1, -0.1, 1},
+				},
+				XAns: []float32{9.2, 15.2, -6.4, 2.3, 13.4, 7.3, 8, -9, 10},
+				YAns: []float32{9, -0.5, 3.4, 7.3, 7.4, -2.3, 7, -6},
+				Name: "ZeroFlag",
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Diagonal,
+					H:    [4]float32{0.5, -1, 1, 0.7},
+				},
+				XAns: []float32{13, 5.5, 1, 8.5, 13, 0.5, 8, -9, 10},
+				YAns: []float32{-4.4, -16.4, 8.8, 1.9, -9.8, -9.1, 7, -6},
+				Name: "OneFlag",
+			},
+		},
+	},
+	{
+		Name:  "PositiveInc",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  2,
+		Incy:  3,
+		N:     3,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{28, -2, 4, -5, 6, -3, 24, 10},
+			},
+		},
+		DdotAns: -18,
+		DswapAns: DTwoVecAnswer{
+			X: []float32{8, 15, 7, 3, -4, 7},
+			Y: []float32{10, -2, 4, -6, 6, -3, 14, 10},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{10, -2, 4, -6, 6, -3, 14, 10},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{12.444023964292095, 15, -2.479518890035003, 3, 10.997835971550302, 7},
+				YAns: []float32{3.024279678886205, -2, 4, 8.879864079700745, 6, -3, -9.541886812516392, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 15, -6.1, 3, 13, 7},
+				YAns: []float32{5, -2, 4, 2.9, 6, -3, -0.6, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.OffDiagonal,
+					H:    [4]float32{1, 0.1, -0.1, 1},
+				},
+				XAns: []float32{9.2, 15, -6.7, 3, 14.4, 7},
+				YAns: []float32{9, -2, 4, 6.4, 6, -3, -2.6, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Diagonal,
+					H:    [4]float32{0.5, -1, 1, 0.7},
+				},
+				XAns: []float32{13, 15, 4, 3, 3, 7},
+				YAns: []float32{-4.4, -2, 4, 10.9, 6, -3, -16.8, 10},
+			},
+		},
+	},
+	{
+		Name:  "NegativeInc",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  -2,
+		Incy:  -3,
+		N:     3,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{28, -2, 4, -5, 6, -3, 24, 10},
+			},
+		},
+		DdotAns: -18,
+		DswapAns: DTwoVecAnswer{
+			X: []float32{8, 15, 7, 3, -4, 7},
+			Y: []float32{10, -2, 4, -6, 6, -3, 14, 10},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{10, -2, 4, -6, 6, -3, 14, 10},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{12.444023964292095, 15, -2.479518890035003, 3, 10.997835971550302, 7},
+				YAns: []float32{3.024279678886205, -2, 4, 8.879864079700745, 6, -3, -9.541886812516392, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 15, -6.1, 3, 13, 7},
+				YAns: []float32{5, -2, 4, 2.9, 6, -3, -0.6, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.OffDiagonal,
+					H:    [4]float32{1, 0.1, -0.1, 1},
+				},
+				XAns: []float32{9.2, 15, -6.7, 3, 14.4, 7},
+				YAns: []float32{9, -2, 4, 6.4, 6, -3, -2.6, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Diagonal,
+					H:    [4]float32{0.5, -1, 1, 0.7},
+				},
+				XAns: []float32{13, 15, 4, 3, 3, 7},
+				YAns: []float32{-4.4, -2, 4, 10.9, 6, -3, -16.8, 10},
+			},
+		},
+	},
+	{
+		Name:  "MixedInc1",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  2,
+		Incy:  -3,
+		N:     3,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DdotAns: 30,
+		DswapAns: DTwoVecAnswer{
+			X: []float32{-4, 15, 7, 3, 8, 7},
+			Y: []float32{14, -2, 4, -6, 6, -3, 10, 10},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{14, -2, 4, -6, 6, -3, 10, 10},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{7.372604823403701, 15, -2.479518890035003, 3, 16.069255112438693, 7},
+				YAns: []float32{1.333806631923407, -2, 4, 8.879864079700745, 6, -3, -7.851413765553595, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{9.4, 15, -6.1, 3, 11.8, 7},
+				YAns: []float32{5.4, -2, 4, 2.9, 6, -3, -1, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.OffDiagonal,
+					H:    [4]float32{1, 0.1, -0.1, 1},
+				},
+				XAns: []float32{10.4, 15, -6.7, 3, 13.2, 7},
+				YAns: []float32{9.4, -2, 4, 6.4, 6, -3, -3, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Diagonal,
+					H:    [4]float32{0.5, -1, 1, 0.7},
+				},
+				XAns: []float32{1, 15, 4, 3, 15, 7},
+				YAns: []float32{-8.4, -2, 4, 10.9, 6, -3, -12.8, 10},
+			},
+		},
+	},
+	{
+		Name:  "MixedInc2",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  -2,
+		Incy:  3,
+		N:     3,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DdotAns: 30,
+		DswapAns: DTwoVecAnswer{
+			X: []float32{-4, 15, 7, 3, 8, 7},
+			Y: []float32{14, -2, 4, -6, 6, -3, 10, 10},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{14, -2, 4, -6, 6, -3, 10, 10},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{7.372604823403701, 15, -2.479518890035003, 3, 16.069255112438693, 7},
+				YAns: []float32{1.333806631923407, -2, 4, 8.879864079700745, 6, -3, -7.851413765553595, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{9.4, 15, -6.1, 3, 11.8, 7},
+				YAns: []float32{5.4, -2, 4, 2.9, 6, -3, -1, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.OffDiagonal,
+					H:    [4]float32{1, 0.1, -0.1, 1},
+				},
+				XAns: []float32{10.4, 15, -6.7, 3, 13.2, 7},
+				YAns: []float32{9.4, -2, 4, 6.4, 6, -3, -3, 10},
+			},
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Diagonal,
+					H:    [4]float32{0.5, -1, 1, 0.7},
+				},
+				XAns: []float32{1, 15, 4, 3, 15, 7},
+				YAns: []float32{-8.4, -2, 4, 10.9, 6, -3, -12.8, 10},
+			},
+		},
+	},
+	{
+		Name:  "ZeroN",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  -2,
+		Incy:  3,
+		N:     0,
+		Panic: false,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DswapAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		},
+		DcopyAns: DTwoVecAnswer{
+			X: []float32{10, 15, -6, 3, 14, 7},
+			Y: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+	},
+	{
+		Name:  "NegativeN",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  -2,
+		Incy:  3,
+		N:     -3,
+		Panic: true,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 13.7, -5.8, 2, 12, 6.6},
+				YAns: []float32{5, 0.5, 1.4, 3.8, 4.4, -0.8},
+			},
+		},
+	},
+	{
+		Name:  "ZeroIncX",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  0,
+		Incy:  3,
+		N:     2,
+		Panic: true,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 13.7, -5.8, 2, 12, 6.6},
+				YAns: []float32{5, 0.5, 1.4, 3.8, 4.4, -0.8},
+			},
+		},
+	},
+	{
+		Name:  "ZeroIncY",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  1,
+		Incy:  0,
+		N:     2,
+		Panic: true,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 13.7, -5.8, 2, 12, 6.6},
+				YAns: []float32{5, 0.5, 1.4, 3.8, 4.4, -0.8},
+			},
+		},
+	},
+	{
+		Name:  "OutOfBoundsX",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  8,
+		Incy:  2,
+		N:     2,
+		Panic: true,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{8.2, 13.7, -5.8, 2, 12, 6.6},
+				YAns: []float32{5, 0.5, 1.4, 3.8, 4.4, -0.8},
+			},
+		},
+	},
+	{
+		Name:  "OutOfBoundsY",
+		X:     []float32{10, 15, -6, 3, 14, 7},
+		Y:     []float32{8, -2, 4, 7, 6, -3, -4, 10},
+		XTmp:  []float32{0, 0, 0, 0, 0, 0},
+		YTmp:  []float32{0, 0, 0, 0, 0, 0, 0, 0},
+		Incx:  2,
+		Incy:  8,
+		N:     2,
+		Panic: true,
+		DaxpyCases: []DaxpyCase{
+			{
+				Alpha: 2,
+				Ans:   []float32{36, -2, 4, -5, 6, -3, 16, 10},
+			},
+		},
+		DrotCases: []DrotCase{
+			{
+				C:    math.Cos(25 * math.Pi / 180),
+				S:    math.Sin(25 * math.Pi / 180),
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+		DrotmCases: []DrotmCase{
+			{
+				P: blas.SrotmParams{
+					Flag: blas.Rescaling,
+					H:    [4]float32{0.9, 0.1, -0.1, 0.5},
+				},
+				XAns: []float32{10, 15, -6, 3, 14, 7},
+				YAns: []float32{8, -2, 4, 7, 6, -3, -4, 10},
+			},
+		},
+	},
+}
+
+type Ddotter interface {
+	Sdot(n int, x []float32, incX int, y []float32, incY int) float32
+}
+
+func DdotTest(t *testing.T, d Ddotter) {
+	ddot := d.Sdot
+	for _, c := range DoubleTwoVectorCases {
+		dCopyTwoTmp(c.X, c.XTmp, c.Y, c.YTmp)
+		if c.Panic {
+			f := func() { ddot(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy) }
+			testpanics(f, c.Name, t)
+			continue
+		}
+		dot := ddot(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy)
+		if !dTolEqual(dot, c.DdotAns) {
+			t.Errorf("ddot: mismatch %v: expected %v, found %v", c.Name, c.DdotAns, dot)
+		}
+	}
+
+	// check it works for 16-byte unaligned slices
+	x := []float32{1, 1, 1, 1, 1}
+	if n := ddot(4, x[:4], 1, x[1:], 1); n != 4 {
+		t.Errorf("ddot: mismatch Unaligned: expected %v, found %v", 4, n)
+	}
+	if n := ddot(2, x[:4], 2, x[1:], 2); n != 2 {
+		t.Errorf("ddot: mismatch Unaligned: expected %v, found %v", 2, n)
+	}
+	if n := ddot(2, x[:4], 3, x[1:], 3); n != 2 {
+		t.Errorf("ddot: mismatch Unaligned: expected %v, found %v", 2, n)
+	}
+}
+
+type Dnrm2er interface {
+	Snrm2(n int, x []float32, incX int) float32
+}
+
+func Dnrm2Test(t *testing.T, blasser Dnrm2er) {
+	dnrm2 := blasser.Snrm2
+	for _, c := range DoubleOneVectorCases {
+		if c.Panic {
+			f := func() { dnrm2(c.N, c.X, c.Incx) }
+			testpanics(f, c.Name, t)
+			continue
+		}
+		v := dnrm2(c.N, c.X, c.Incx)
+		if !dTolEqual(v, c.Snrm2) {
+			t.Errorf("dnrm2: mismatch %v: expected %v, found %v", c.Name, c.Snrm2, v)
+		}
+	}
+}
+
+type Dasumer interface {
+	Sasum(n int, x []float32, incX int) float32
+}
+
+func DasumTest(t *testing.T, blasser Dasumer) {
+	dasum := blasser.Sasum
+	for _, c := range DoubleOneVectorCases {
+		if c.Panic {
+			f := func() { dasum(c.N, c.X, c.Incx) }
+			testpanics(f, c.Name, t)
+			continue
+		}
+		v := dasum(c.N, c.X, c.Incx)
+		if !dTolEqual(v, c.Sasum) {
+			t.Errorf("dasum: mismatch %v: expected %v, found %v", c.Name, c.Sasum, v)
+		}
+	}
+}
+
+type Idamaxer interface {
+	Isamax(n int, x []float32, incX int) int
+}
+
+func IdamaxTest(t *testing.T, blasser Idamaxer) {
+	idamax := blasser.Isamax
+	for _, c := range DoubleOneVectorCases {
+		if c.Panic {
+			f := func() { idamax(c.N, c.X, c.Incx) }
+			testpanics(f, c.Name, t)
+			continue
+		}
+		v := idamax(c.N, c.X, c.Incx)
+		if v != c.Isamax {
+			t.Errorf("idamax: mismatch %v: expected %v, found %v", c.Name, c.Isamax, v)
+		}
+	}
+}
+
+type Dswapper interface {
+	Sswap(n int, x []float32, incX int, y []float32, incY int)
+}
+
+func DswapTest(t *testing.T, d Dswapper) {
+	dswap := d.Sswap
+	for _, c := range DoubleTwoVectorCases {
+		dCopyTwoTmp(c.X, c.XTmp, c.Y, c.YTmp)
+		if c.Panic {
+			f := func() { dswap(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy) }
+			testpanics(f, c.Name, t)
+			continue
+		}
+		dswap(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy)
+		if !dSliceTolEqual(c.XTmp, c.DswapAns.X) {
+			t.Errorf("dswap: x mismatch %v: expected %v, found %v", c.Name, c.DswapAns.X, c.XTmp)
+		}
+		if !dSliceTolEqual(c.YTmp, c.DswapAns.Y) {
+			t.Errorf("dswap: y mismatch %v: expected %v, found %v", c.Name, c.DswapAns.Y, c.YTmp)
+		}
+	}
+}
+
+type Dcopier interface {
+	Scopy(n int, x []float32, incX int, y []float32, incY int)
+}
+
+func DcopyTest(t *testing.T, d Dcopier) {
+	dcopy := d.Scopy
+	for _, c := range DoubleTwoVectorCases {
+		dCopyTwoTmp(c.X, c.XTmp, c.Y, c.YTmp)
+		if c.Panic {
+			f := func() { dcopy(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy) }
+			testpanics(f, c.Name, t)
+			continue
+		}
+		dcopy(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy)
+		if !dSliceTolEqual(c.XTmp, c.DcopyAns.X) {
+			t.Errorf("dswap: x mismatch %v: expected %v, found %v", c.Name, c.DcopyAns.X, c.XTmp)
+		}
+		if !dSliceTolEqual(c.YTmp, c.DcopyAns.Y) {
+			t.Errorf("dswap: y mismatch %v: expected %v, found %v", c.Name, c.DcopyAns.Y, c.YTmp)
+		}
+	}
+}
+
+type Daxpyer interface {
+	Saxpy(n int, alpha float32, x []float32, incX int, y []float32, incY int)
+}
+
+func DaxpyTest(t *testing.T, d Daxpyer) {
+	daxpy := d.Saxpy
+	for _, c := range DoubleTwoVectorCases {
+		for _, kind := range c.DaxpyCases {
+			dCopyTwoTmp(c.X, c.XTmp, c.Y, c.YTmp)
+			if c.Panic {
+				f := func() { daxpy(c.N, kind.Alpha, c.XTmp, c.Incx, c.YTmp, c.Incy) }
+				testpanics(f, c.Name, t)
+				continue
+			}
+			daxpy(c.N, kind.Alpha, c.XTmp, c.Incx, c.YTmp, c.Incy)
+			if !dSliceTolEqual(c.YTmp, kind.Ans) {
+				t.Errorf("daxpy: mismatch %v: expected %v, found %v", c.Name, kind.Ans, c.YTmp)
+			}
+		}
+	}
+}
+
+type DrotgTestStruct struct {
+	Name       string
+	A, B       float32
+	C, S, R, Z float32
+}
+
+var DrotgTests = []DrotgTestStruct{
+	{
+		Name: "ZeroAB",
+		C:    1,
+	},
+	{
+		Name: "PosA_ZeroB",
+		A:    0.5,
+		C:    1,
+		R:    0.5,
+	},
+	{
+		Name: "NegA_ZeroB",
+		A:    -4.6,
+		C:    1,
+		R:    -4.6,
+	},
+	{
+		Name: "ZeroA_PosB",
+		B:    3,
+		S:    1,
+		R:    3,
+		Z:    1,
+	},
+	{
+		Name: "ZeroA_NegB",
+		B:    -0.3,
+		S:    1,
+		R:    -0.3,
+		Z:    1,
+	},
+	{
+		Name: "PosA_PosB_AGTB",
+		A:    5,
+		B:    0.3,
+		C:    0.99820484546577868593549038000,
+		S:    0.05989229072794672115612942280,
+		R:    5.00899191454727744602429072688,
+		Z:    0.05989229072794672115612942280,
+	},
+	{
+		Name: "PosA_PosB_ALTB",
+		A:    3,
+		B:    4,
+		C:    3.0 / 5,
+		S:    4.0 / 5,
+		R:    5,
+		Z:    5.0 / 3.0,
+	},
+
+	{
+		Name: "PosA_NegB_AGTB",
+		A:    2.6,
+		B:    -0.9,
+		C:    0.94498607344025815971847507095,
+		S:    -0.32711056388316628605639521686,
+		R:    2.751363298439520872718790879655,
+		Z:    -0.3271105638831662860563952168,
+	},
+	{
+		Name: "PosA_NegB_ALTB",
+		A:    2.6,
+		B:    -2.9,
+		C:    -0.6675450157520258540548049558,
+		S:    0.7445694406464903756765132200,
+		R:    -3.8948684188300893100043812234,
+		Z:    1 / -0.6675450157520258540548049558,
+	},
+	{
+		Name: "NegA_PosB_AGTB",
+		A:    -11.4,
+		B:    10.3,
+		C:    0.7419981952497362418487847947,
+		S:    -0.6704018781642353764072353847,
+		R:    -15.363918770938617534070671122,
+		Z:    -0.6704018781642353764072353847,
+	},
+	{
+		Name: "NegA_PosB_ALTB",
+		A:    -1.4,
+		B:    10.3,
+		C:    -0.1346838895922121112404717523,
+		S:    0.9908886162855605326977564640,
+		R:    10.394710193170370442523552032,
+		Z:    1 / -0.1346838895922121112404717523,
+	},
+	{
+		Name: "NegA_NegB_AGTB",
+		A:    -11.4,
+		B:    10.3,
+		C:    0.7419981952497362418487847947,
+		S:    -0.6704018781642353764072353847,
+		R:    -15.363918770938617534070671122,
+		Z:    -0.6704018781642353764072353847,
+	},
+	{
+		Name: "NegA_NegB_ALTB",
+		A:    -1.4,
+		B:    -10.3,
+		C:    0.1346838895922121112404717523,
+		S:    0.9908886162855605326977564640,
+		R:    -10.394710193170370442523552032,
+		Z:    1 / 0.1346838895922121112404717523,
+	},
+}
+
+type Drotger interface {
+	Srotg(a, b float32) (c, s, r, z float32)
+}
+
+func DrotgTest(t *testing.T, d Drotger) {
+	drotg := d.Srotg
+	for _, test := range DrotgTests {
+		c, s, r, z := drotg(test.A, test.B)
+		if !dTolEqual(c, test.C) {
+			t.Errorf("drotg: c mismatch %v: expected %v, found %v", test.Name, test.C, c)
+		}
+		if !dTolEqual(s, test.S) {
+			t.Errorf("drotg: s mismatch %v: expected %v, found %v", test.Name, test.S, s)
+		}
+		if !dTolEqual(r, test.R) {
+			t.Errorf("drotg: r mismatch %v: expected %v, found %v", test.Name, test.R, r)
+		}
+		if !dTolEqual(z, test.Z) {
+			t.Errorf("drotg: z mismatch %v: expected %v, found %v", test.Name, test.Z, z)
+		}
+	}
+}
+
+type DrotmgTestStruct struct {
+	Name           string
+	D1, D2, X1, Y1 float32
+	P              *blas.SrotmParams
+	Rd1, Rd2, Rx1  float32
+}
+
+var DrotmgTests = []DrotmgTestStruct{
+	{
+		Name: "NegD1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+		},
+		D1: -4,
+		D2: 6,
+		X1: 8,
+		Y1: -4,
+	},
+	{
+		Name: "ZeroD2",
+		P: &blas.SrotmParams{
+			Flag: blas.Identity,
+		},
+		D1:  4,
+		X1:  8,
+		Y1:  -5,
+		Rd1: 4,
+		Rx1: 8,
+	},
+	{
+		Name: "ZeroY1",
+		P: &blas.SrotmParams{
+			Flag: blas.Identity,
+		},
+		D1:  4,
+		D2:  -6,
+		X1:  8,
+		Rd1: 4,
+		Rd2: -6,
+		Rx1: 8,
+	},
+	{
+		Name: "NegQ2_and_AQ1_LT_AQ2",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+		},
+		D1:  8,
+		D2:  -6,
+		X1:  4,
+		Y1:  8,
+		Rd1: 0,
+		Rd2: 0,
+		Rx1: 0,
+	},
+	{
+		Name: "ZeroD1",
+		P: &blas.SrotmParams{
+			Flag: blas.Diagonal,
+			H:    [4]float32{0, 0, 0, 2},
+		},
+		D1:  0,
+		D2:  2,
+		X1:  8,
+		Y1:  4,
+		Rd1: 2,
+		Rd2: 0,
+		Rx1: 4,
+	},
+	{
+		Name: "AbsQ1_GT_AbsQU__D2_Pos",
+		P: &blas.SrotmParams{
+			Flag: blas.OffDiagonal,
+			H:    [4]float32{0, -0.625, 0.9375, 0},
+		},
+		D1:  2,
+		D2:  3,
+		X1:  8,
+		Y1:  5,
+		Rd1: 1.2610837438423645,
+		Rd2: 1.8916256157635467,
+		Rx1: 12.6875,
+	},
+	{
+		Name: "AbsQ1_GT_AbsQU__D2_Neg",
+		P: &blas.SrotmParams{
+			Flag: blas.OffDiagonal,
+			H:    [4]float32{0, -0.625, -0.9375, 0},
+		},
+		D1:  2,
+		D2:  -3,
+		X1:  8,
+		Y1:  5,
+		Rd1: 4.830188679245283,
+		Rd2: -7.245283018867925,
+		Rx1: 3.3125,
+	},
+	{
+		Name: "AbsQ1_LT_AbsQU__D2_Pos",
+		P: &blas.SrotmParams{
+			Flag: blas.Diagonal,
+			H:    [4]float32{5.0 / 12, 0, 0, 0.625},
+		},
+		D1:  2,
+		D2:  3,
+		X1:  5,
+		Y1:  8,
+		Rd1: 2.3801652892561984,
+		Rd2: 1.586776859504132,
+		Rx1: 121.0 / 12,
+	},
+	{
+		Name: "D1=D2_X1=X2",
+		P: &blas.SrotmParams{
+			Flag: blas.Diagonal,
+			H:    [4]float32{1, 0, 0, 1},
+		},
+		D1:  2,
+		D2:  2,
+		X1:  8,
+		Y1:  8,
+		Rd1: 1,
+		Rd2: 1,
+		Rx1: 16,
+	},
+	{
+		Name: "RD1_Big_RD2_Big_Flag_0",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{4096, -3584, 1792, 4096},
+		},
+		D1:  1600000000,
+		D2:  800000000,
+		X1:  8,
+		Y1:  7,
+		Rd1: 68.96627824858757,
+		Rd2: 34.483139124293785,
+		Rx1: 45312,
+	},
+	{
+		Name: "RD1_Big_RD2_Big_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{2340.5714285714284, -4096, 4096, 4681.142857142857},
+		},
+		D1:  800000000,
+		D2:  1600000000,
+		X1:  8,
+		Y1:  7,
+		Rd1: 57.6914092640818,
+		Rd2: 28.8457046320409,
+		Rx1: 47396.57142857142,
+	},
+	{
+		Name: "RD1_Big_RD2_Med_Flag_0",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{4096, -1, 0.0004096, 1},
+		},
+		D1:  20000000,
+		D2:  2,
+		X1:  8,
+		Y1:  8,
+		Rd1: 1.1920927762985347,
+		Rd2: 1.9999998000000199,
+		Rx1: 32768.0032768,
+	},
+	{
+		Name: "RD1_Big_RD2_Med_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{4.096e-17, -1, 4096, 1e-10},
+		},
+		D1:  2,
+		D2:  20000000000,
+		X1:  8,
+		Y1:  80000000000,
+		Rd1: 1192.0928955078125,
+		Rd2: 2,
+		Rx1: 3.2768e+14,
+	},
+
+	// TODO: Add D1 big, D2 small, Flag = 0
+	{
+		Name: "D1_Big_D2_Small_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{2.8671999999999997e-26, -0.000244140625, 4096, 2.44140625e-16},
+		},
+		D1:  0.000000014,
+		D2:  2000000000,
+		X1:  0.000008,
+		Y1:  8000000,
+		Rd1: 119.20928955078125,
+		Rd2: 0.234881024,
+		Rx1: 3.2768e+10,
+	},
+
+	{
+		Name: "RD1_Med_RD2_Big_Flag_0",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{1, -0.0004096, 1000, 4096},
+		},
+		D1:  2,
+		D2:  20000000000,
+		X1:  80000000,
+		Y1:  8,
+		Rd1: 1.9998000199980002,
+		Rd2: 1191.9736981379988,
+		Rx1: 8.0008e+07,
+	},
+	{
+		Name: "D1_Med_D2_Big_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{50, -4096, 1, 4.096e-06},
+		},
+		D1:  20000000000,
+		D2:  0.4,
+		X1:  80000000,
+		Y1:  80000000000000000,
+		Rd1: 0.39999998000000103,
+		Rd2: 1192.092835903171,
+		Rx1: 8.0000004e+16,
+	},
+	{
+		Name: "RD1_Med_RD2_Small_Flag_0",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{1, -0.0007233796296296296, 1.1111111111111111e-10, 0.000244140625},
+		},
+		D1:  1.2,
+		D2:  0.000000000045,
+		X1:  2.7,
+		Y1:  8,
+		Rd1: 1.1999999996049382,
+		Rd2: 0.0007549747197514486,
+		Rx1: 2.700000000888889,
+	},
+	{
+		Name: "RD1_Med_RD2_Small_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{0.0002197265625, -1, 0.000244140625, 3.375e-11},
+		},
+		D1:  1.2,
+		D2:  0.000000000045,
+		X1:  2.7,
+		Y1:  80000000000,
+		Rd1: 0.0007549747199770676,
+		Rd2: 1.19999999996355,
+		Rx1: 1.9531250000593264e+07,
+	},
+	// TODO: Add Small, Big, 0 case
+	{
+		Name: "D1_Small_D2_Big_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{2.3731773997569866e+10, -1.6777216e+07, 0.000244140625, 1.6777216e-07},
+		},
+		D1:  120000000000000000,
+		D2:  0.000000000012345,
+		X1:  0.08,
+		Y1:  8000000000000,
+		Rd1: 0.00010502490698765249,
+		Rd2: 216.1836123957717,
+		Rx1: 3.8516669198055897e+09,
+	},
+	{
+		Name: "RD1_Small_RD2_Med_Flag_0",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{0.000244140625, -1e-08, 0.24414062499999997, 1},
+		},
+		D1:  0.0000000002,
+		D2:  20,
+		X1:  0.8,
+		Y1:  0.000000008,
+		Rd1: 0.003355409645903541,
+		Rd2: 19.99980000199998,
+		Rx1: 0.000195314453125,
+	},
+	{
+		Name: "RD1_Small_RD2_Med_Flag_1",
+		P: &blas.SrotmParams{
+			Flag: blas.Rescaling,
+			H:    [4]float32{0.0012207031250000002, -1, 0.000244140625, 1e-09},
+		},
+		D1:  0.02,
+		D2:  0.000000000004,
+		X1:  0.008,
+		Y1:  8000000,
+		Rd1: 6.710886366445568e-05,
+		Rd2: 0.019999999900000003,
+		Rx1: 1953.125009765625,
+	},
+	// TODO: Add Small, Small, 0 case
+	// TODO: Add Small, Small, 1 case
+}
+
+type Drotmger interface {
+	Srotmg(d1, d2, x1, y1 float32) (p blas.SrotmParams, rd1, rd2, rx1 float32)
+}
+
+func DrotmgTest(t *testing.T, d Drotmger) {
+	for _, test := range DrotmgTests {
+
+		p, rd1, rd2, rx1 := d.Srotmg(test.D1, test.D2, test.X1, test.Y1)
+
+		if p.Flag != test.P.Flag {
+			t.Errorf("drotmg flag mismatch %v: expected %v, found %v", test.Name, test.P.Flag, p.Flag)
+		}
+		for i, val := range p.H {
+			if !dTolEqual(test.P.H[i], val) {
+				t.Errorf("drotmg H mismatch %v: expected %v, found %v", test.Name, test.P.H, p.H)
+				break
+			}
+		}
+		if !dTolEqual(rd1, test.Rd1) {
+			t.Errorf("drotmg rd1 mismatch %v: expected %v, found %v", test.Name, test.Rd1, rd1)
+		}
+		if !dTolEqual(rd2, test.Rd2) {
+			t.Errorf("drotmg rd2 mismatch %v: expected %v, found %v", test.Name, test.Rd2, rd2)
+		}
+		if !dTolEqual(rx1, test.Rx1) {
+			t.Errorf("drotmg rx1 mismatch %v: expected %v, found %v", test.Name, test.Rx1, rx1)
+		}
+	}
+}
+
+type Droter interface {
+	Srot(n int, x []float32, incX int, y []float32, incY int, c, s float32)
+}
+
+func DrotTest(t *testing.T, d Droter) {
+	drot := d.Srot
+	for _, c := range DoubleTwoVectorCases {
+		for _, kind := range c.DrotCases {
+			dCopyTwoTmp(c.X, c.XTmp, c.Y, c.YTmp)
+			if c.Panic {
+				f := func() { drot(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy, kind.C, kind.S) }
+				testpanics(f, c.Name, t)
+				continue
+			}
+			drot(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy, kind.C, kind.S)
+			if !dSliceTolEqual(c.XTmp, kind.XAns) {
+				t.Errorf("drot: x mismatch %v: expected %v, found %v", c.Name, kind.XAns, c.XTmp)
+			}
+			if !dSliceTolEqual(c.YTmp, kind.YAns) {
+				t.Errorf("drot: y mismatch %v: expected %v, found %v", c.Name, kind.YAns, c.YTmp)
+			}
+		}
+	}
+}
+
+type Drotmer interface {
+	Srotm(n int, x []float32, incX int, y []float32, incY int, p blas.SrotmParams)
+}
+
+func DrotmTest(t *testing.T, d Drotmer) {
+	drotm := d.Srotm
+	for _, c := range DoubleTwoVectorCases {
+		for _, kind := range c.DrotmCases {
+			dCopyTwoTmp(c.X, c.XTmp, c.Y, c.YTmp)
+			if c.Panic {
+				f := func() { drotm(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy, kind.P) }
+				testpanics(f, c.Name+", "+kind.Name, t)
+				continue
+			}
+			drotm(c.N, c.XTmp, c.Incx, c.YTmp, c.Incy, kind.P)
+			if !dSliceTolEqual(c.XTmp, kind.XAns) {
+				t.Errorf("drotm: mismatch %v: expected %v, found %v", c.Name, kind.XAns, c.XTmp)
+			}
+			if !dSliceTolEqual(c.YTmp, kind.YAns) {
+				t.Errorf("drotm: mismatch %v: expected %v, found %v", c.Name, kind.YAns, c.YTmp)
+			}
+		}
+	}
+}
+
+type Dscaler interface {
+	Sscal(n int, alpha float32, x []float32, incX int)
+}
+
+func DscalTest(t *testing.T, blasser Dscaler) {
+	dscal := blasser.Sscal
+	for _, c := range DoubleOneVectorCases {
+		for _, kind := range c.DscalCases {
+			xTmp := make([]float32, len(c.X))
+			copy(xTmp, c.X)
+			if c.Panic {
+				f := func() { dscal(c.N, kind.Alpha, xTmp, c.Incx) }
+				testpanics(f, c.Name, t)
+				continue
+			}
+			dscal(c.N, kind.Alpha, xTmp, c.Incx)
+			if !dSliceTolEqual(xTmp, kind.Ans) {
+				t.Errorf("dscal: mismatch %v, %v: expected %v, found %v", c.Name, kind.Name, kind.Ans, xTmp)
+			}
+		}
+	}
+}

--- a/testblas/single/single.go
+++ b/testblas/single/single.go
@@ -1,0 +1,7 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:generate ./generate.sh
+
+package single


### PR DESCRIPTION
I initially started by adding the test functions in testblas package, but that turned out to be too tedious. You have to rename a LOT of local identifiers (TestX, XCase, XCases, functions in common.go, etc.). I really think testblas should be split up into sub-packages for each type (testblas/single, testblas/double, etc.). It'd also help to split up blas/native into sub-packages. It's more idiomatic to have small simple packages instead of monolithic packages. It leads to smaller binaries. There are some guidelines in the recent [Go package naming blog post](http://blog.golang.org/package-names) (in particular see "Break up generic packages" section).

This PR probably shouldn't be merged until the packages are split up.
