### PR TITLE
travis: add check for running go generate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
   # at some point, when the issue with drotgm is resolved
   #- BLAS_LIB=ATLAS
 
-# Required for coverage.
 before_install:
+ # Required for coverage.
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
 
@@ -27,7 +27,7 @@ install:
  - source .travis/$TRAVIS_OS_NAME/$BLAS_LIB/install.sh
  - go get github.com/gonum/floats
 
-# Get deps, build, test, and ensure the code is gofmt'ed.
+# Get deps, build, test, ensure the code is gofmt'ed and check that go generate was run.
 # Move into the native directory if we aren't using an external blas lib.
 # If we are building as gonum, then we have access to the coveralls api key, so we can run coverage as well.
 script:
@@ -37,3 +37,5 @@ script:
  - go test -a -tags noasm -v ./...
  - diff <(gofmt -d .) <("")
  - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash -c "${TRAVIS_BUILD_DIR}/.travis/test-coverage.sh"; fi
+ # This is run last since it alters the tree.
+ - ${TRAVIS_BUILD_DIR}/.travis/check-generate.sh

--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+go generate github.com/gonum/blas/cgo
+go generate github.com/gonum/blas/native
+if [ -n "$(git diff)" ]; then
+	exit 1
+fi

--- a/cgo/doc.go
+++ b/cgo/doc.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:generate ./genBlas.pl
+
 // Ensure changes made to blas/cgo are reflected in blas/native where relevant.
 
 /*


### PR DESCRIPTION
@vladimir-ch Please take a look.

I have tested that this picks up generated differences on travis and it does except in g1.3.3 which has no go generate (you will see this in the travis build history).