### PR TITLE
native: Use asm.Dscal in Dscal

### DIFF
--- a/native/level1double.go
+++ b/native/level1double.go
@@ -601,10 +601,7 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 		return
 	}
 	if incX == 1 {
-		x = x[:n]
-		for i := range x {
-			x[i] *= alpha
-		}
+		asm.DscalUnitary(alpha, x[:n])
 		return
 	}
 	for ix := 0; ix < n*incX; ix += incX {

--- a/native/level1double.go
+++ b/native/level1double.go
@@ -578,16 +578,14 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 		}
 		return
 	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic(badX)
 	}
 	if n < 1 {
 		if n == 0 {
 			return
 		}
-		if n < 1 {
-			panic(negativeN)
-		}
+		panic(negativeN)
 	}
 	if alpha == 0 {
 		if incX == 1 {
@@ -595,10 +593,12 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 			for i := range x {
 				x[i] = 0
 			}
+			return
 		}
 		for ix := 0; ix < n*incX; ix += incX {
 			x[ix] = 0
 		}
+		return
 	}
 	if incX == 1 {
 		x = x[:n]
@@ -610,5 +610,4 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	for ix := 0; ix < n*incX; ix += incX {
 		x[ix] *= alpha
 	}
-	return
 }

--- a/native/level1single.go
+++ b/native/level1single.go
@@ -602,16 +602,14 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 		}
 		return
 	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic(badX)
 	}
 	if n < 1 {
 		if n == 0 {
 			return
 		}
-		if n < 1 {
-			panic(negativeN)
-		}
+		panic(negativeN)
 	}
 	if alpha == 0 {
 		if incX == 1 {
@@ -619,20 +617,18 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 			for i := range x {
 				x[i] = 0
 			}
+			return
 		}
 		for ix := 0; ix < n*incX; ix += incX {
 			x[ix] = 0
 		}
+		return
 	}
 	if incX == 1 {
-		x = x[:n]
-		for i := range x {
-			x[i] *= alpha
-		}
+		asm.SscalUnitary(alpha, x[:n])
 		return
 	}
 	for ix := 0; ix < n*incX; ix += incX {
 		x[ix] *= alpha
 	}
-	return
 }

--- a/native/single_precision
+++ b/native/single_precision
@@ -23,6 +23,7 @@ cat level1double.go \
 | gofmt -r 'asm.DaxpyUnitaryTo -> asm.SaxpyUnitaryTo' \
 | gofmt -r 'asm.DdotInc -> asm.SdotInc' \
 | gofmt -r 'asm.DdotUnitary -> asm.SdotUnitary' \
+| gofmt -r 'asm.DscalUnitary -> asm.SscalUnitary' \
 \
 | sed -e "s_^\(func (Implementation) \)D\(.*\)\$_$WARNING\1S\2_" \
       -e 's_^// D_// S_' \


### PR DESCRIPTION
I wonder if we shouldn't keep the PosInc case as Go loop. Also, mat64.Vector does not allow negative inc, BLAS does nothing when negative inc, so we could safely drop the last argument from the assembler routines.
```
% benchstat before.txt after.txt 
name                   old time/op  new time/op  delta
DscalSmallUnitaryInc   12.6ns ± 0%   9.4ns ± 0%  -25.26%  (p=0.029 n=4+4)
DscalSmallPosInc       13.4ns ± 0%  13.2ns ± 0%   -1.49%  (p=0.029 n=4+4)
DscalMediumUnitaryInc   690ns ± 0%   164ns ± 0%  -76.25%  (p=0.029 n=4+4)
DscalMediumPosInc      1.14µs ± 0%  1.15µs ± 0%   +1.36%  (p=0.029 n=4+4)
DscalLargeUnitaryInc   71.1µs ± 0%  42.8µs ± 0%  -39.87%  (p=0.029 n=4+4)
DscalLargePosInc        197µs ± 0%   183µs ± 1%   -7.44%  (p=0.029 n=4+4)
DscalHugeUnitaryInc    9.92ms ± 1%  8.00ms ± 1%  -19.38%  (p=0.029 n=4+4)
DscalHugePosInc        41.4ms ± 0%  41.1ms ± 0%   -0.76%  (p=0.029 n=4+4)
```