### PR TITLE
add OpenBLAS build for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
   - os: linux
     env: BLAS_LIB=ATLAS
   - os: osx
-    env: BLAS_LIB=OpenBLAS
-  - os: osx
     env: BLAS_LIB=ATLAS
 
 before_install:

--- a/.travis/osx/OpenBLAS/install.sh
+++ b/.travis/osx/OpenBLAS/install.sh
@@ -1,0 +1,6 @@
+brew install homebrew/science/openblas
+export CGO_LDFLAGS="-L/usr/local/opt/openblas/lib -lopenblas"
+go get github.com/gonum/blas
+pushd cgo
+go install -v -x
+popd


### PR DESCRIPTION
Installed via homebrew.  It takes about twice as long as the linux builds for OpenBLAS, because `brew install` also runs a bunch of tests, which may be redundant.  Follows #161

PTAL @btracey @vladimir-ch 