### PR TITLE
Exclude OpenBLAS on osx from the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
     env: BLAS_LIB=ATLAS
   - os: osx
     env: BLAS_LIB=ATLAS
+  - os: osx
+    env: BLAS_LIB=OpenBLAS
 
 before_install:
  # Required for coverage.


### PR DESCRIPTION
It takes more than 10m to make openblas, and the travis builds are automatically terminated if they take too long without returning any input.  Maybe the homebrew installation script does too much, maybe it should be verbose, or maybe the travis servers are slow right now, but in any case I don't want to show the build as erroring when it just timed out in a semi-redundant environment.