### PR TITLE
Change make flags in favor of compilation speed

### DIFF
--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -10,7 +10,7 @@ sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS
 # make OpenBLAS
 pushd OpenBLAS
 echo OpenBLAS $(git rev-parse HEAD)
-sudo make FC=gfortran &> /dev/null && sudo make PREFIX=/usr install
+sudo make FC=gfortran COMMON_OPT=-O0 -s libs netlib shared &> /dev/null && sudo make PREFIX=/usr -s install
 popd
 
 # fetch cblas reference lib
@@ -19,7 +19,7 @@ curl http://www.netlib.org/blas/blast-forum/cblas.tgz | tar -zx
 # make cblas and install
 pushd CBLAS
 sudo mv Makefile.LINUX Makefile.in
-sudo BLLIB=/usr/lib/libopenblas.a make alllib
+sudo make BLLIB=/usr/lib/libopenblas.a CFLAGS="-O0 -DADD_" FFLAGS=-O0 -s alllib
 sudo mv lib/cblas_LINUX.a /usr/lib/libcblas.a
 popd
 popd


### PR DESCRIPTION
This changes the make flags to only use -O0 when compiling (previously -O3 and -O2 were used), and avoids calling make test.  Should be somewhat faster for compilation.