### PR TITLE
remove path exclusion from git diff

### DIFF
--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 go generate github.com/gonum/blas/cgo
 go generate github.com/gonum/blas/native

--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -2,6 +2,6 @@
 
 go generate github.com/gonum/blas/cgo
 go generate github.com/gonum/blas/native
-if [ -n "$(git diff -- . ':!.travis')" ]; then
+if [ -n "$(git diff)" ]; then
 	exit 1
 fi


### PR DESCRIPTION
Looks like the :!.travis exclusion rule is not implemented in the version of git that travis is using.

This pull will also have to make changes to the CI process so that the directory is actually unchanged, instead of just ignored.