### PR TITLE
Fix math_test.go for Go1.9

### DIFF
--- a/native/internal/math32/math_test.go
+++ b/native/internal/math32/math_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gonum/floats"
 )
 
-const tol = 1e-7
+const tol = 1e-6
 
 func TestAbs(t *testing.T) {
 	f := func(x float32) bool {


### PR DESCRIPTION
https://golang.org/cl/39152 fixes the testing/quick package to properly generate
all possible uint64 values which affects the range of values that are generated
for float32. This causes some inputs to be provided that exceeds the 1e-7 
tolerance previously set. Instead, we increase it to 1e-6.